### PR TITLE
Add module scaffolding generator and module guide

### DIFF
--- a/MODULE_GUIDE.md
+++ b/MODULE_GUIDE.md
@@ -1,0 +1,111 @@
+# Module Development Guide
+
+This service template embraces two complementary development paradigms so that teams can choose the right balance between delivery speed and long-term maintainability. Both styles plug into a shared application bootstrap layer implemented in [`internal/server`](internal/server), which assembles infrastructure in `bootstrap.go`, exposes lifecycle management in `app.go`, and routes requests through `router.go` before dispatching them to registered modules listed in `modules.go`.
+
+## Why two paradigms?
+
+- **Structured / Dependency Injection (DI)** keeps dependencies explicit and testable. It is ideal for complex, business-critical features where lifecycle control, migrations, and robust testing matter most. The `auth` module is the canonical example.
+- **Simple / Singleton-first** favours rapid iteration by leaning on globally initialised infrastructure such as `database.Default()` or `logger.Default()`. It is perfect for thin CRUD endpoints, admin utilities, or experiments where speed outweighs ceremony. The `role` module showcases this approach.
+
+Supporting both patterns lets new contributors start fast while giving senior engineers a clear path for extracting durable, well-factored domains when requirements grow.
+
+## Choosing the right paradigm
+
+Run through this quick checklist whenever you create a module:
+
+- [ ] Does the feature touch core business workflows or sensitive data paths?
+- [ ] Will the module require migrations, background jobs, or integration tests?
+- [ ] Do you expect complex dependency graphs (multiple repositories, third-party clients, etc.)?
+- [ ] Is long-term ownership shared across teams or does it demand strict boundaries?
+- [ ] Do you need fine-grained observability (custom metrics, tracing spans, structured logs)?
+
+If you answered “yes” to most questions, start with the **structured/DI** template. A majority of “no” answers means the **simple/singleton** template is usually sufficient—refactor to the structured pattern later if the module evolves.
+
+## Structured pattern (auth module)
+
+The `auth` module highlights explicit wiring from repository to handler, making dependencies easy to follow and mock.
+
+```go
+// internal/auth/register.go
+func Register(ctx context.Context, deps module.Dependencies) error {
+        if deps.DB == nil {
+                return fmt.Errorf("auth module requires a database instance")
+        }
+
+        repo := NewRepository(deps.DB)
+        if err := repo.Migrate(ctx); err != nil {
+                return fmt.Errorf("run migrations: %w", err)
+        }
+
+        svc := NewService(repo)
+        handler := NewHandler(svc)
+        handler.RegisterRoutes(deps.API)
+
+        if deps.Logger != nil {
+                deps.Logger.Info("auth module initialised", "pattern", "structured")
+        }
+
+        return nil
+}
+```
+
+Dependencies flow in a single direction: `NewRepository` → `NewService` → `NewHandler`. Each layer is easy to test in isolation and only receives what it needs. The module depends on the shared router group exposed by the bootstrap layer, but everything else stays local.
+
+## Simple pattern (role module)
+
+The `role` module keeps the surface area tiny by calling global singletons directly from the handler.
+
+```go
+// internal/role/handler.go
+func (h *Handler) create(c *gin.Context) {
+        var req createRoleRequest
+        if err := c.ShouldBindJSON(&req); err != nil {
+                c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+                return
+        }
+
+        userID, err := uuid.Parse(req.UserID)
+        if err != nil {
+                c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id"})
+                return
+        }
+
+        db := database.Default()
+        if db == nil {
+                c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialised"})
+                return
+        }
+
+        record := assignment{UserID: userID, Role: req.Role}
+        if err := db.WithContext(c.Request.Context()).Create(&record).Error; err != nil {
+                c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+                return
+        }
+
+        c.JSON(http.StatusCreated, gin.H{
+                "id":           record.ID,
+                "user_id":      record.UserID,
+                "role":         record.Role,
+                "date_created": record.DateCreated,
+        })
+}
+```
+
+There is no explicit wiring layer: the handler reaches for `database.Default()` when it needs persistence and returns early if the service is not ready. This keeps code generation small and accelerates prototyping.
+
+## Scaffolding new modules
+
+Use the `make new-module` automation to eliminate repetitive setup:
+
+```bash
+make new-module name=inventory type=structured
+make new-module name=audit type=simple
+```
+
+The generator will:
+
+1. Create `internal/<name>/` with either the DI (repository/service/handler/register) or singleton (handler/register) template.
+2. Wire the module into [`internal/server/modules.go`](internal/server/modules.go) so it is registered automatically during bootstrap.
+3. Leave the bootstrap, router, and middleware untouched—new modules plug directly into the existing lifecycle.
+
+After scaffolding, fill in repository methods, flesh out services, and replace placeholder routes with real logic. The rest of the application (configuration, database, logger, metrics, telemetry) is already available through `module.Dependencies` or singleton helpers.

--- a/cmd/newmodule/main.go
+++ b/cmd/newmodule/main.go
@@ -1,0 +1,512 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"go/format"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"text/template"
+	"unicode"
+)
+
+var (
+	moduleNamePattern  = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+	reservedModuleName = map[string]struct{}{
+		"module": {},
+		"server": {},
+	}
+)
+
+func main() {
+	var (
+		nameArg = flag.String("name", "", "module name (lowercase, underscores allowed)")
+		typeArg = flag.String("type", "", "module type: simple or structured")
+		rootArg = flag.String("root", ".", "project root directory")
+	)
+
+	flag.Parse()
+
+	name := strings.TrimSpace(*nameArg)
+	moduleType := strings.ToLower(strings.TrimSpace(*typeArg))
+	root := strings.TrimSpace(*rootArg)
+
+	if name == "" {
+		exitWithError(errors.New("module name is required"))
+	}
+
+	name = strings.ToLower(name)
+	if !moduleNamePattern.MatchString(name) {
+		exitWithError(fmt.Errorf("module name %q is invalid: only lowercase letters, digits and underscores are allowed", name))
+	}
+
+	if moduleType != "simple" && moduleType != "structured" {
+		exitWithError(fmt.Errorf("module type %q is invalid: must be simple or structured", moduleType))
+	}
+
+	if root == "" {
+		root = "."
+	}
+
+	if _, exists := reservedModuleName[name]; exists {
+		exitWithError(fmt.Errorf("module name %q is reserved", name))
+	}
+
+	if err := run(root, name, moduleType); err != nil {
+		exitWithError(err)
+	}
+}
+
+func exitWithError(err error) {
+	fmt.Fprintf(os.Stderr, "newmodule: %v\n", err)
+	os.Exit(1)
+}
+
+func run(root, name, moduleType string) error {
+	moduleDir := filepath.Join(root, "internal", name)
+	if _, err := os.Stat(moduleDir); err == nil {
+		return fmt.Errorf("module directory %s already exists", moduleDir)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("check module directory: %w", err)
+	}
+
+	if err := os.MkdirAll(moduleDir, 0o755); err != nil {
+		return fmt.Errorf("create module directory: %w", err)
+	}
+
+	data := templateData{
+		Package:     name,
+		Name:        name,
+		Route:       "/" + name,
+		DisplayName: displayName(name),
+		LogMessage:  fmt.Sprintf("%s module initialised", displayName(name)),
+	}
+
+	files := map[string][]byte{}
+	var err error
+	switch moduleType {
+	case "simple":
+		files, err = renderSimpleModule(data)
+	case "structured":
+		files, err = renderStructuredModule(data)
+	}
+	if err != nil {
+		return err
+	}
+
+	for filename, content := range files {
+		path := filepath.Join(moduleDir, filename)
+		if err := os.WriteFile(path, content, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", path, err)
+		}
+	}
+
+	modulePath, err := goModulePath(root)
+	if err != nil {
+		return fmt.Errorf("determine module path: %w", err)
+	}
+
+	if err := updateModulesFile(root, modulePath, name); err != nil {
+		return fmt.Errorf("update module registry: %w", err)
+	}
+
+	return nil
+}
+
+type templateData struct {
+	Package     string
+	Name        string
+	Route       string
+	DisplayName string
+	LogMessage  string
+}
+
+func renderSimpleModule(data templateData) (map[string][]byte, error) {
+	handler, err := renderGoTemplate(simpleHandlerTemplate, data)
+	if err != nil {
+		return nil, err
+	}
+
+	register, err := renderGoTemplate(simpleRegisterTemplate, data)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string][]byte{
+		"handler.go":  handler,
+		"register.go": register,
+	}, nil
+}
+
+func renderStructuredModule(data templateData) (map[string][]byte, error) {
+	repository, err := renderGoTemplate(structuredRepositoryTemplate, data)
+	if err != nil {
+		return nil, err
+	}
+
+	service, err := renderGoTemplate(structuredServiceTemplate, data)
+	if err != nil {
+		return nil, err
+	}
+
+	handler, err := renderGoTemplate(structuredHandlerTemplate, data)
+	if err != nil {
+		return nil, err
+	}
+
+	register, err := renderGoTemplate(structuredRegisterTemplate, data)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string][]byte{
+		"repository.go": repository,
+		"service.go":    service,
+		"handler.go":    handler,
+		"register.go":   register,
+	}, nil
+}
+
+func renderGoTemplate(tmpl string, data templateData) ([]byte, error) {
+	t, err := template.New("module").Parse(tmpl)
+	if err != nil {
+		return nil, fmt.Errorf("parse template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, data); err != nil {
+		return nil, fmt.Errorf("execute template: %w", err)
+	}
+
+	formatted, err := format.Source(buf.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("format source: %w", err)
+	}
+
+	return formatted, nil
+}
+
+func goModulePath(root string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(root, "go.mod"))
+	if err != nil {
+		return "", err
+	}
+
+	lines := strings.Split(string(data), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "module ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "module ")), nil
+		}
+	}
+
+	return "", errors.New("module path not found in go.mod")
+}
+
+func updateModulesFile(root, modulePath, moduleName string) error {
+	modulesPath := filepath.Join(root, "internal", "server", "modules.go")
+	content, err := os.ReadFile(modulesPath)
+	if err != nil {
+		return err
+	}
+
+	importPath := fmt.Sprintf("%s/internal/%s", modulePath, moduleName)
+	if strings.Contains(string(content), importPath) {
+		return fmt.Errorf("module %q is already registered", moduleName)
+	}
+
+	alias := fmt.Sprintf("%smodule", moduleName)
+	reference := alias
+	if reference == "" {
+		reference = moduleName
+	}
+
+	updated, err := insertImport(string(content), alias, importPath)
+	if err != nil {
+		return err
+	}
+
+	updated, err = insertModuleEntry(updated, moduleName, reference)
+	if err != nil {
+		return err
+	}
+
+	formatted, err := format.Source([]byte(updated))
+	if err != nil {
+		return fmt.Errorf("format modules.go: %w", err)
+	}
+
+	if err := os.WriteFile(modulesPath, formatted, 0o644); err != nil {
+		return fmt.Errorf("write modules.go: %w", err)
+	}
+
+	return nil
+}
+
+func insertImport(content, alias, path string) (string, error) {
+	const importKeyword = "import ("
+
+	idx := strings.Index(content, importKeyword)
+	if idx == -1 {
+		return "", errors.New("import block not found in modules.go")
+	}
+
+	blockStart := idx + len(importKeyword)
+	blockEnd := strings.Index(content[blockStart:], ")")
+	if blockEnd == -1 {
+		return "", errors.New("import block not terminated in modules.go")
+	}
+
+	insertPos := blockStart + blockEnd
+
+	var line string
+	if alias != "" {
+		line = fmt.Sprintf("\t%s \"%s\"\n", alias, path)
+	} else {
+		line = fmt.Sprintf("\t\"%s\"\n", path)
+	}
+
+	return content[:insertPos] + line + content[insertPos:], nil
+}
+
+func insertModuleEntry(content, moduleName, reference string) (string, error) {
+	const marker = "var Modules = []module.Entry{"
+
+	idx := strings.Index(content, marker)
+	if idx == -1 {
+		return "", errors.New("Modules slice not found in modules.go")
+	}
+
+	openIdx := idx + len(marker) - 1
+	closingIdx, err := findClosingBrace(content, openIdx)
+	if err != nil {
+		return "", err
+	}
+
+	entry := fmt.Sprintf("\t{Name: \"%s\", Registrar: %s.Register},\n", moduleName, reference)
+	return content[:closingIdx] + entry + content[closingIdx:], nil
+}
+
+func findClosingBrace(content string, openIdx int) (int, error) {
+	depth := 0
+	for i := openIdx; i < len(content); i++ {
+		switch content[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i, nil
+			}
+		}
+	}
+
+	return -1, errors.New("matching closing brace not found")
+}
+
+func displayName(name string) string {
+	parts := strings.FieldsFunc(name, func(r rune) bool {
+		return r == '_' || r == '-'
+	})
+	if len(parts) == 0 {
+		return title(name)
+	}
+
+	for i, part := range parts {
+		parts[i] = title(part)
+	}
+
+	return strings.Join(parts, " ")
+}
+
+func title(word string) string {
+	if word == "" {
+		return ""
+	}
+
+	runes := []rune(word)
+	runes[0] = unicode.ToUpper(runes[0])
+	for i := 1; i < len(runes); i++ {
+		runes[i] = unicode.ToLower(runes[i])
+	}
+
+	return string(runes)
+}
+
+const simpleHandlerTemplate = `package {{.Package}}
+
+import (
+        "net/http"
+
+        "github.com/gin-gonic/gin"
+
+        "github.com/Jayleonc/service/pkg/database"
+        "github.com/Jayleonc/service/pkg/logger"
+)
+
+type Handler struct{}
+
+func NewHandler() *Handler {
+        return &Handler{}
+}
+
+func (h *Handler) RegisterRoutes(rg *gin.RouterGroup) {
+        if rg == nil {
+                return
+        }
+
+        rg.GET("{{.Route}}/ping", h.ping)
+}
+
+func (h *Handler) ping(c *gin.Context) {
+        log := logger.Default()
+        if log != nil {
+                log.Debug("{{.DisplayName}} ping received")
+        }
+
+        db := database.Default()
+        if db == nil {
+                c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialised"})
+                return
+        }
+
+        c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+`
+
+const simpleRegisterTemplate = `package {{.Package}}
+
+import (
+        "context"
+        "fmt"
+
+        "github.com/Jayleonc/service/internal/module"
+)
+
+func Register(ctx context.Context, deps module.Dependencies) error {
+        if deps.API == nil {
+                return fmt.Errorf("{{.Name}} module requires the API router group")
+        }
+
+        handler := NewHandler()
+        handler.RegisterRoutes(deps.API)
+
+        if deps.Logger != nil {
+                deps.Logger.InfoContext(ctx, "{{.LogMessage}}", "pattern", "singleton")
+        }
+
+        return nil
+}
+`
+
+const structuredRepositoryTemplate = `package {{.Package}}
+
+import "gorm.io/gorm"
+
+type Repository struct {
+        db *gorm.DB
+}
+
+func NewRepository(db *gorm.DB) *Repository {
+        return &Repository{db: db}
+}
+`
+
+const structuredServiceTemplate = `package {{.Package}}
+
+import (
+        "context"
+        "fmt"
+)
+
+type Service struct {
+        repo *Repository
+}
+
+func NewService(repo *Repository) *Service {
+        return &Service{repo: repo}
+}
+
+func (s *Service) Ping(ctx context.Context) error {
+        if ctx == nil {
+                return fmt.Errorf("context is required")
+        }
+        if s.repo == nil {
+                return fmt.Errorf("repository not configured")
+        }
+        return nil
+}
+`
+
+const structuredHandlerTemplate = `package {{.Package}}
+
+import (
+        "net/http"
+
+        "github.com/gin-gonic/gin"
+)
+
+type Handler struct {
+        service *Service
+}
+
+func NewHandler(service *Service) *Handler {
+        return &Handler{service: service}
+}
+
+func (h *Handler) RegisterRoutes(rg *gin.RouterGroup) {
+        if rg == nil {
+                return
+        }
+
+        rg.GET("{{.Route}}/ping", h.ping)
+}
+
+func (h *Handler) ping(c *gin.Context) {
+        if h.service == nil {
+                c.JSON(http.StatusInternalServerError, gin.H{"error": "service not configured"})
+                return
+        }
+
+        if err := h.service.Ping(c.Request.Context()); err != nil {
+                c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+                return
+        }
+
+        c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+`
+
+const structuredRegisterTemplate = `package {{.Package}}
+
+import (
+        "context"
+        "fmt"
+
+        "github.com/Jayleonc/service/internal/module"
+)
+
+func Register(ctx context.Context, deps module.Dependencies) error {
+        if deps.DB == nil {
+                return fmt.Errorf("{{.Name}} module requires a database instance")
+        }
+        if deps.API == nil {
+                return fmt.Errorf("{{.Name}} module requires the API router group")
+        }
+
+        repo := NewRepository(deps.DB)
+        svc := NewService(repo)
+        handler := NewHandler(svc)
+        handler.RegisterRoutes(deps.API)
+
+        if deps.Logger != nil {
+                deps.Logger.InfoContext(ctx, "{{.LogMessage}}", "pattern", "structured")
+        }
+
+        return nil
+}
+`

--- a/makefile
+++ b/makefile
@@ -403,6 +403,17 @@ lint:
 	CGO_ENABLED=0 go vet ./...
 	staticcheck -checks=all ./...
 
+new-module:
+	@if [ -z "$(name)" ]; then \
+		echo "usage: make new-module name=<module> type=<simple|structured>"; \
+		exit 1; \
+	fi
+	@if [ -z "$(type)" ]; then \
+		echo "usage: make new-module name=<module> type=<simple|structured>"; \
+		exit 1; \
+	fi
+	go run ./cmd/newmodule -name=$(name) -type=$(type)
+
 vuln-check:
 	govulncheck ./...
 
@@ -613,3 +624,6 @@ help:
 	@echo "  dev-logs-loki           Show the logs for the loki service"
 	@echo "  dev-logs-promtail       Show the logs for the promtail service"
 	@echo "  dev-services-delete     Delete all"
+	@echo "  lint                    Run go vet and staticcheck"
+	@echo "  new-module              Scaffold a new module (name=<module> type=<simple|structured>)"
+	@echo "  test                    Run tests and checks"


### PR DESCRIPTION
## Summary
- add MODULE_GUIDE.md to document the dual structured/singleton module paradigms and decision checklist
- add cmd/newmodule generator that scaffolds simple or structured modules and updates the module registry automatically
- wire a make new-module helper and help output so new modules can be created with one command

## Testing
- make lint *(fails: staticcheck: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8d3952ba0832f9c719eb83db0a26f