### PR TITLE
feat: add interactive project CLI

### DIFF
--- a/MODULE_GUIDE.md
+++ b/MODULE_GUIDE.md
@@ -95,11 +95,10 @@ There is no explicit wiring layer: the handler reaches for `database.Default()` 
 
 ## Scaffolding new modules
 
-Use the `make new-module` automation to eliminate repetitive setup:
+Use the `make new-module` automation to eliminate repetitive setup. The command launches an interactive wizard, so no flags are required:
 
 ```bash
-make new-module name=inventory type=structured
-make new-module name=audit type=simple
+make new-module
 ```
 
 The generator will:

--- a/README.md
+++ b/README.md
@@ -58,9 +58,20 @@ Both modules share the same router instance and live side-by-side without leakin
 
 ## Quick Start
 
-1. Install Go 1.22 or newer.
-2. Ensure PostgreSQL is available and export configuration through the `AUTH_` environment variables (defaults point to `localhost:5432`).
-3. Run the service:
+1. Clone this repository and change into the project directory.
+2. Rebrand the module path for your organisation by running the interactive initialiser:
+
+   ```bash
+   make init-project
+   ```
+
+3. Scaffold your first feature module with the guided generator:
+
+   ```bash
+   make new-module
+   ```
+
+4. Run the service:
 
    ```bash
    go run ./cmd/service

--- a/makefile
+++ b/makefile
@@ -403,16 +403,11 @@ lint:
 	CGO_ENABLED=0 go vet ./...
 	staticcheck -checks=all ./...
 
+init-project:
+	@go run ./cmd/project-cli init
+
 new-module:
-	@if [ -z "$(name)" ]; then \
-		echo "usage: make new-module name=<module> type=<simple|structured>"; \
-		exit 1; \
-	fi
-	@if [ -z "$(type)" ]; then \
-		echo "usage: make new-module name=<module> type=<simple|structured>"; \
-		exit 1; \
-	fi
-	go run ./cmd/newmodule -name=$(name) -type=$(type)
+	@go run ./cmd/project-cli new-module
 
 vuln-check:
 	govulncheck ./...


### PR DESCRIPTION
## Summary
- replace the old newmodule tool with a project-cli that exposes init and new-module subcommands with interactive prompts
- add a project initialiser that rewrites the module path across text files and reuse existing scaffolding logic under the new CLI
- expose make targets for init/new-module and refresh docs to highlight the new workflow

## Testing
- make lint *(fails: staticcheck not installed in CI image)*


------
https://chatgpt.com/codex/tasks/task_e_68d8eb0a3434832fb86379a10c683256