### PR TITLE
Simplify server bootstrap to rely on gin.Run

### DIFF
--- a/cmd/service/main.go
+++ b/cmd/service/main.go
@@ -1,44 +1,21 @@
 package main
 
 import (
-	"context"
+	"fmt"
 	"log/slog"
-	"net/http"
-	"os"
-	"os/signal"
-	"syscall"
-	"time"
 
 	"github.com/Jayleonc/service/internal/server"
 )
 
 func main() {
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
-	defer stop()
-
-	app, err := server.Bootstrap(ctx, os.Args[1:])
+	app, err := server.Bootstrap()
 	if err != nil {
 		slog.Error("failed to bootstrap application", "error", err)
-		os.Exit(1)
+		return
 	}
 
-	errCh := app.Start()
-
-	select {
-	case <-ctx.Done():
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-
-		if err := app.Shutdown(shutdownCtx); err != nil {
-			slog.Error("graceful shutdown failed", "error", err)
-		}
-
-		if err := <-errCh; err != nil && err != http.ErrServerClosed {
-			slog.Error("server terminated unexpectedly", "error", err)
-		}
-	case err := <-errCh:
-		if err != nil && err != http.ErrServerClosed {
-			slog.Error("server terminated unexpectedly", "error", err)
-		}
+	addr := fmt.Sprintf("%s:%d", app.Config.Server.Host, app.Config.Server.Port)
+	if err := app.Router.Run(addr); err != nil {
+		slog.Error("server exited", "error", err)
 	}
 }

--- a/internal/server/app.go
+++ b/internal/server/app.go
@@ -1,68 +1,25 @@
 package server
 
 import (
-	"context"
-	"errors"
 	"log/slog"
-	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/Jayleonc/service/pkg/config"
 )
 
-// App coordinates the lifecycle of the HTTP server and shared infrastructure.
+// App holds the initialized Gin engine and shared configuration for the service.
 type App struct {
-	server    *http.Server
-	logger    *slog.Logger
-	shutdowns []func(context.Context) error
+	Router *gin.Engine
+	Config config.App
+	Logger *slog.Logger
 }
 
-// NewApp constructs an application instance ready to be started.
-func NewApp(logger *slog.Logger, server *http.Server, shutdowns ...func(context.Context) error) *App {
+// NewApp constructs an application instance that wraps the engine and configuration.
+func NewApp(router *gin.Engine, cfg config.App, logger *slog.Logger) *App {
 	return &App{
-		server:    server,
-		logger:    logger,
-		shutdowns: shutdowns,
+		Router: router,
+		Config: cfg,
+		Logger: logger,
 	}
-}
-
-// Start begins serving HTTP traffic asynchronously and returns a channel that
-// emits the outcome of the listener.
-func (a *App) Start() <-chan error {
-	errCh := make(chan error, 1)
-
-	go func() {
-		a.logger.Info("starting http server", "addr", a.server.Addr)
-
-		if err := a.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			a.logger.Error("http server terminated", "error", err)
-			errCh <- err
-			return
-		}
-
-		errCh <- nil
-	}()
-
-	return errCh
-}
-
-// Shutdown gracefully stops the HTTP server and runs any registered shutdown hooks.
-func (a *App) Shutdown(ctx context.Context) error {
-	a.logger.Info("shutting down http server")
-
-	var joined error
-
-	if err := a.server.Shutdown(ctx); err != nil {
-		joined = errors.Join(joined, err)
-	}
-
-	for _, fn := range a.shutdowns {
-		if fn == nil {
-			continue
-		}
-
-		if err := fn(ctx); err != nil {
-			a.logger.Error("shutdown hook failed", "error", err)
-			joined = errors.Join(joined, err)
-		}
-	}
-
-	return joined
 }


### PR DESCRIPTION
## Summary
- replace the service entrypoint with a minimal gin.Engine bootstrap and run call
- rework the server App container to expose the gin router and application config
- update bootstrap to assemble dependencies and return the simplified App without manual HTTP server management

## Testing
- make lint *(fails: staticcheck: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8ee762608832fbd1cafb23b1ab57d