### PR TITLE
Refactor routing contracts and rename modules to features

### DIFF
--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -1,21 +1,21 @@
 package app
 
 import (
-	"github.com/Jayleonc/service/internal/auth"
-	"github.com/Jayleonc/service/internal/module"
-	"github.com/Jayleonc/service/internal/role"
-	"github.com/Jayleonc/service/internal/server"
-	"github.com/Jayleonc/service/internal/user"
+        "github.com/Jayleonc/service/internal/auth"
+        "github.com/Jayleonc/service/internal/feature"
+        "github.com/Jayleonc/service/internal/role"
+        "github.com/Jayleonc/service/internal/server"
+        "github.com/Jayleonc/service/internal/user"
 )
 
-// Modules enumerates all modules that should be initialised at startup.
-var Modules = []module.Entry{
-	{Name: "auth", Registrar: auth.Register},
-	{Name: "role", Registrar: role.Register},
-	{Name: "user", Registrar: user.Register},
+// Features enumerates all features that should be initialised at startup.
+var Features = []feature.Entry{
+        {Name: "auth", Registrar: auth.Register},
+        {Name: "role", Registrar: role.Register},
+        {Name: "user", Registrar: user.Register},
 }
 
-// Bootstrap assembles the shared infrastructure and registers every module.
+// Bootstrap assembles the shared infrastructure and registers every feature.
 func Bootstrap() (*server.App, error) {
-	return server.Bootstrap(Modules)
+        return server.Bootstrap(Features)
 }

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/Jayleonc/service/internal/server"
+	"github.com/Jayleonc/service/internal/feature"
 	"github.com/Jayleonc/service/pkg/response"
 )
 
@@ -20,10 +20,10 @@ func NewHandler(svc *Service) *Handler {
 	return &Handler{svc: svc}
 }
 
-// GetRoutes 声明认证模块的路由
-func (h *Handler) GetRoutes() server.ModuleRoutes {
-	return server.ModuleRoutes{
-		PublicRoutes: []server.RouteDefinition{
+// GetRoutes 声明认证功能的路由
+func (h *Handler) GetRoutes() feature.ModuleRoutes {
+	return feature.ModuleRoutes{
+		PublicRoutes: []feature.RouteDefinition{
 			{Path: "/auth/refresh", Handler: h.refresh},
 		},
 	}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,4 +1,4 @@
-package middleware
+package auth
 
 import (
 	"net/http"
@@ -6,12 +6,12 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/Jayleonc/service/internal/auth"
+	"github.com/Jayleonc/service/internal/feature"
 	"github.com/Jayleonc/service/pkg/response"
 )
 
-// Authenticated ensures the request has a valid JWT token.
-func Authenticated(service *auth.Service) gin.HandlerFunc {
+// AuthenticatedMiddleware ensures the request has a valid JWT token and stores the session in context.
+func AuthenticatedMiddleware(service *Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		header := c.GetHeader("Authorization")
 		if header == "" {
@@ -34,7 +34,7 @@ func Authenticated(service *auth.Service) gin.HandlerFunc {
 			return
 		}
 
-		auth.SetContextSession(c, session)
+		feature.SetContextSession(c, session)
 		c.Next()
 	}
 }

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/Jayleonc/service/internal/feature"
 	authpkg "github.com/Jayleonc/service/pkg/auth"
 )
 
@@ -50,7 +51,7 @@ func (s *Service) IssueTokens(ctx context.Context, userID uuid.UUID, roles []str
 		return Tokens{}, err
 	}
 
-	session := SessionData{
+	session := feature.SessionData{
 		SessionID:    sessionID,
 		UserID:       userID,
 		Roles:        roles,
@@ -95,15 +96,15 @@ func (s *Service) Refresh(ctx context.Context, refreshToken string) (Tokens, err
 }
 
 // Validate extracts the session from the access token.
-func (s *Service) Validate(ctx context.Context, token string) (SessionData, error) {
+func (s *Service) Validate(ctx context.Context, token string) (feature.SessionData, error) {
 	claims, err := s.manager.ParseToken(token)
 	if err != nil {
-		return SessionData{}, err
+		return feature.SessionData{}, err
 	}
 
 	session, err := s.store.Get(ctx, claims.SessionID)
 	if err != nil {
-		return SessionData{}, err
+		return feature.SessionData{}, err
 	}
 
 	return session, nil

--- a/internal/feature/guards.go
+++ b/internal/feature/guards.go
@@ -1,0 +1,10 @@
+package feature
+
+import "github.com/gin-gonic/gin"
+
+// RouteGuards captures the middleware stacks applied to feature routes.
+type RouteGuards struct {
+        Public        []gin.HandlerFunc
+        Authenticated []gin.HandlerFunc
+        Admin         []gin.HandlerFunc
+}

--- a/internal/feature/module.go
+++ b/internal/feature/module.go
@@ -19,7 +19,7 @@ type RouteRegistrar interface {
 	RegisterModule(pathPrefix string, routes ModuleRoutes)
 }
 
-// Dependencies captures the shared infrastructure that modules can leverage during registration.
+// Dependencies captures the shared infrastructure that features can leverage during registration.
 type Dependencies struct {
 	Logger    *slog.Logger
 	DB        *gorm.DB
@@ -30,9 +30,10 @@ type Dependencies struct {
 	Config    config.App
 	Cache     *redis.Client
 	Validator *validator.Validate
+	Guards    *RouteGuards
 }
 
-// Registrar declares the signature that modules must implement to self-register.
+// Registrar declares the signature that features must implement to self-register.
 type Registrar func(context.Context, Dependencies) error
 
 // Entry associates a human-friendly name with a registrar implementation.

--- a/internal/feature/routes.go
+++ b/internal/feature/routes.go
@@ -8,7 +8,7 @@ type RouteDefinition struct {
 	Handler gin.HandlerFunc
 }
 
-// ModuleRoutes 是一个模块对外暴露的、按权限划分的路由清单
+// ModuleRoutes 是一个功能对外暴露的、按权限划分的路由清单
 type ModuleRoutes struct {
 	PublicRoutes        []RouteDefinition
 	AuthenticatedRoutes []RouteDefinition

--- a/internal/feature/session.go
+++ b/internal/feature/session.go
@@ -1,12 +1,18 @@
-package auth
+package feature
 
-import "github.com/gin-gonic/gin"
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
 
 const contextSessionKey = "auth.session"
 
-// ContextSessionKey exposes the key used to store session data in Gin's context.
-func ContextSessionKey() string {
-	return contextSessionKey
+// SessionData captures the authenticated user context shared between features.
+type SessionData struct {
+	SessionID    string
+	UserID       uuid.UUID
+	Roles        []string
+	RefreshToken string
 }
 
 // SetContextSession stores the authenticated session data into the Gin context.

--- a/internal/middleware/rbac.go
+++ b/internal/middleware/rbac.go
@@ -1,13 +1,13 @@
 package middleware
 
 import (
-	"net/http"
-	"strings"
+        "net/http"
+        "strings"
 
-	"github.com/gin-gonic/gin"
+        "github.com/gin-gonic/gin"
 
-	"github.com/Jayleonc/service/internal/auth"
-	"github.com/Jayleonc/service/pkg/response"
+        "github.com/Jayleonc/service/internal/feature"
+        "github.com/Jayleonc/service/pkg/response"
 )
 
 // RBAC ensures that the authenticated user has at least one of the required roles.
@@ -27,7 +27,7 @@ func RBAC(requiredRoles ...string) gin.HandlerFunc {
 	}
 
 	return func(c *gin.Context) {
-		session, ok := auth.SessionFromContext(c)
+                session, ok := feature.SessionFromContext(c)
 		if !ok {
 			response.Error(c, http.StatusUnauthorized, 2051, "missing session")
 			c.Abort()

--- a/internal/role/handler.go
+++ b/internal/role/handler.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 
-	"github.com/Jayleonc/service/internal/server"
+	"github.com/Jayleonc/service/internal/feature"
 	"github.com/Jayleonc/service/pkg/response"
 )
 
@@ -20,10 +20,10 @@ func NewHandler(svc *Service) *Handler {
 	return &Handler{svc: svc}
 }
 
-// GetRoutes 返回角色模块的路由定义
-func (h *Handler) GetRoutes() server.ModuleRoutes {
-	return server.ModuleRoutes{
-		AdminRoutes: []server.RouteDefinition{
+// GetRoutes 返回角色功能的路由定义
+func (h *Handler) GetRoutes() feature.ModuleRoutes {
+	return feature.ModuleRoutes{
+		AdminRoutes: []feature.RouteDefinition{
 			{Path: "/roles/create", Handler: h.create},
 			{Path: "/roles/update", Handler: h.update},
 			{Path: "/roles/delete", Handler: h.delete},

--- a/internal/role/register.go
+++ b/internal/role/register.go
@@ -5,26 +5,25 @@ import (
 	"fmt"
 
 	"github.com/Jayleonc/service/internal/auth"
-	"github.com/Jayleonc/service/internal/module"
-	"github.com/Jayleonc/service/internal/server"
+	"github.com/Jayleonc/service/internal/feature"
 	"github.com/Jayleonc/service/pkg/constant"
 )
 
-// Register initialises the role module following the singleton-friendly path.
-func Register(ctx context.Context, deps module.Dependencies) error {
+// Register initialises the role feature following the singleton-friendly path.
+func Register(ctx context.Context, deps feature.Dependencies) error {
 	if deps.DB == nil {
-		return fmt.Errorf("role module requires a database instance")
+		return fmt.Errorf("role feature requires a database instance")
 	}
-	if deps.API == nil {
-		return fmt.Errorf("role module requires an API router group")
+	if deps.Router == nil {
+		return fmt.Errorf("role feature requires a route registrar")
 	}
 	if deps.Validator == nil {
-		return fmt.Errorf("role module requires a validator instance")
+		return fmt.Errorf("role feature requires a validator instance")
 	}
 
 	authService := auth.DefaultService()
 	if authService == nil {
-		return fmt.Errorf("role module requires the auth service to be initialised")
+		return fmt.Errorf("role feature requires the auth service to be initialised")
 	}
 
 	repo := NewRepository(deps.DB)
@@ -41,10 +40,10 @@ func Register(ctx context.Context, deps module.Dependencies) error {
 	}
 
 	handler := NewHandler(svc)
-	server.RegisterModuleRoutes(deps.API, authService, handler.GetRoutes())
+	deps.Router.RegisterModule("", handler.GetRoutes())
 
 	if deps.Logger != nil {
-		deps.Logger.Info("role module initialised", "pattern", "singleton")
+		deps.Logger.Info("role feature initialised", "pattern", "singleton")
 	}
 
 	return nil

--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -6,8 +6,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 
-	"github.com/Jayleonc/service/internal/auth"
-	"github.com/Jayleonc/service/internal/server"
+	"github.com/Jayleonc/service/internal/feature"
 	"github.com/Jayleonc/service/pkg/request"
 	"github.com/Jayleonc/service/pkg/response"
 )
@@ -22,18 +21,18 @@ func NewHandler(svc *Service) *Handler {
 	return &Handler{svc: svc}
 }
 
-// GetRoutes returns the route declarations for the user module.
-func (h *Handler) GetRoutes() server.ModuleRoutes {
-	return server.ModuleRoutes{
-		PublicRoutes: []server.RouteDefinition{
+// GetRoutes returns the route declarations for the user feature.
+func (h *Handler) GetRoutes() feature.ModuleRoutes {
+	return feature.ModuleRoutes{
+		PublicRoutes: []feature.RouteDefinition{
 			{Path: "/users/register", Handler: h.register},
 			{Path: "/users/login", Handler: h.login},
 		},
-		AuthenticatedRoutes: []server.RouteDefinition{
+		AuthenticatedRoutes: []feature.RouteDefinition{
 			{Path: "/users/me/get", Handler: h.me},
 			{Path: "/users/me/update", Handler: h.updateMe},
 		},
-		AdminRoutes: []server.RouteDefinition{
+		AdminRoutes: []feature.RouteDefinition{
 			{Path: "/users/create", Handler: h.create},
 			{Path: "/users/update", Handler: h.update},
 			{Path: "/users/delete", Handler: h.delete},
@@ -92,7 +91,7 @@ func (h *Handler) login(c *gin.Context) {
 }
 
 func (h *Handler) me(c *gin.Context) {
-	session, ok := auth.SessionFromContext(c)
+	session, ok := feature.SessionFromContext(c)
 	if !ok {
 		response.Error(c, http.StatusUnauthorized, 3021, "missing session")
 		return
@@ -108,7 +107,7 @@ func (h *Handler) me(c *gin.Context) {
 }
 
 func (h *Handler) updateMe(c *gin.Context) {
-	session, ok := auth.SessionFromContext(c)
+	session, ok := feature.SessionFromContext(c)
 	if !ok {
 		response.Error(c, http.StatusUnauthorized, 3031, "missing session")
 		return

--- a/internal/user/register.go
+++ b/internal/user/register.go
@@ -5,26 +5,25 @@ import (
 	"fmt"
 
 	"github.com/Jayleonc/service/internal/auth"
-	"github.com/Jayleonc/service/internal/module"
+	"github.com/Jayleonc/service/internal/feature"
 	"github.com/Jayleonc/service/internal/role"
-	"github.com/Jayleonc/service/internal/server"
 )
 
-// Register wires the user module using the structured/DI development path.
-func Register(ctx context.Context, deps module.Dependencies) error {
+// Register wires the user feature using the structured/DI development path.
+func Register(ctx context.Context, deps feature.Dependencies) error {
 	if deps.DB == nil {
-		return fmt.Errorf("user module requires a database instance")
+		return fmt.Errorf("user feature requires a database instance")
 	}
-	if deps.API == nil {
-		return fmt.Errorf("user module requires an API router group")
+	if deps.Router == nil {
+		return fmt.Errorf("user feature requires a route registrar")
 	}
 	if deps.Validator == nil {
-		return fmt.Errorf("user module requires a validator instance")
+		return fmt.Errorf("user feature requires a validator instance")
 	}
 
 	authService := auth.DefaultService()
 	if authService == nil {
-		return fmt.Errorf("user module requires the auth service to be initialised")
+		return fmt.Errorf("user feature requires the auth service to be initialised")
 	}
 
 	repo := NewRepository(deps.DB)
@@ -35,10 +34,10 @@ func Register(ctx context.Context, deps module.Dependencies) error {
 	roleRepo := role.NewRepository(deps.DB)
 	svc := NewService(repo, roleRepo, deps.Validator, authService)
 	handler := NewHandler(svc)
-	server.RegisterModuleRoutes(deps.API, authService, handler.GetRoutes())
+	deps.Router.RegisterModule("", handler.GetRoutes())
 
 	if deps.Logger != nil {
-		deps.Logger.Info("user module initialised", "pattern", "structured")
+		deps.Logger.Info("user feature initialised", "pattern", "structured")
 	}
 
 	return nil

--- a/makefile
+++ b/makefile
@@ -406,8 +406,8 @@ lint:
 init-project:
 	@go run ./cmd/project-cli init
 
-new-module:
-	@go run ./cmd/project-cli new-module
+new-feature:
+        @go run ./cmd/project-cli new-feature
 
 vuln-check:
 	govulncheck ./...
@@ -620,5 +620,5 @@ help:
 	@echo "  dev-logs-promtail       Show the logs for the promtail service"
 	@echo "  dev-services-delete     Delete all"
 	@echo "  lint                    Run go vet and staticcheck"
-	@echo "  new-module              Scaffold a new module (name=<module> type=<simple|structured>)"
+        @echo "  new-feature             Scaffold a new feature (name=<feature> type=<simple|structured>)"
 	@echo "  test                    Run tests and checks"


### PR DESCRIPTION
## Summary
- replace the shared router helper with a stateful Router that manages feature guards
- centralise session context handling inside the feature package and remove the middleware/auth dependency cycle
- update feature registrars, generator templates, and docs to use the new feature terminology

## Testing
- go build ./...
- go vet ./...


------
https://chatgpt.com/codex/tasks/task_e_68d91bc3c6f4832fa397665cf971908e