### PR TITLE
Add RBAC repository, service, and HTTP tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/redis/go-redis/v9 v9.14.0
 	github.com/spf13/viper v1.18.2
+	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.63.0
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.38.0
@@ -17,6 +18,7 @@ require (
 	golang.org/x/crypto v0.41.0
 	gorm.io/driver/mysql v1.6.0
 	gorm.io/driver/postgres v1.5.8
+	gorm.io/driver/sqlite v1.5.7
 	gorm.io/gorm v1.30.0
 )
 
@@ -28,6 +30,7 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.10 // indirect
@@ -51,11 +54,13 @@ require (
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-sqlite3 v1.14.22 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
@@ -65,6 +70,7 @@ require (
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0V
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -135,6 +137,8 @@ github.com/spf13/viper v1.18.2/go.mod h1:EKmWIqdnk5lOcmR72yw6hS+8OPYcwD0jteitLMV
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -213,5 +217,7 @@ gorm.io/driver/mysql v1.6.0 h1:eNbLmNTpPpTOVZi8MMxCi2aaIm0ZpInbORNXDwyLGvg=
 gorm.io/driver/mysql v1.6.0/go.mod h1:D/oCC2GWK3M/dqoLxnOlaNKmXz8WNTfcS9y5ovaSqKo=
 gorm.io/driver/postgres v1.5.8 h1:RzXgvWnzagHjzP5JD4kiWOEZgHtFl5TSem9EuUra4p8=
 gorm.io/driver/postgres v1.5.8/go.mod h1:sxF2SpBI1/VIwVNML0fS1F+vex+MEdKmWWeYzeWsfM0=
+gorm.io/driver/sqlite v1.5.7 h1:8NvsrhP0ifM7LX9G4zPB97NwovUakUxc+2V2uuf3Z1I=
+gorm.io/driver/sqlite v1.5.7/go.mod h1:U+J8craQU6Fzkcvu8oLeAQmi50TkwPEhHDEjQZXDah4=
 gorm.io/gorm v1.30.0 h1:qbT5aPv1UH8gI99OsRlvDToLxW5zR7FzS9acZDOZcgs=
 gorm.io/gorm v1.30.0/go.mod h1:8Z33v652h4//uMA76KjeDH8mJXPm1QNCYrMeatR0DOE=

--- a/internal/rbac/handler.go
+++ b/internal/rbac/handler.go
@@ -1,6 +1,7 @@
 package rbac
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
@@ -14,13 +15,29 @@ import (
 
 // Handler exposes management APIs for the RBAC module.
 type Handler struct {
-	svc *Service
+	svc ServiceContract
+}
+
+// ServiceContract 定义了 Handler 所需的服务层能力。
+type ServiceContract interface {
+	CreateRole(ctx context.Context, input CreateRoleInput) (*Role, error)
+	UpdateRole(ctx context.Context, input UpdateRoleInput) (*Role, error)
+	DeleteRole(ctx context.Context, input DeleteRoleInput) error
+	ListRoles(ctx context.Context) ([]Role, error)
+	AssignPermissions(ctx context.Context, input AssignRolePermissionsInput) (*Role, error)
+	GetRolePermissions(ctx context.Context, roleID uuid.UUID) ([]string, error)
+	CreatePermission(ctx context.Context, input CreatePermissionInput) (*Permission, error)
+	UpdatePermission(ctx context.Context, input UpdatePermissionInput) (*Permission, error)
+	DeletePermission(ctx context.Context, input DeletePermissionInput) error
+	ListPermissions(ctx context.Context) ([]Permission, error)
 }
 
 // NewHandler constructs a handler with the provided service dependency.
 func NewHandler(svc *Service) *Handler {
 	return &Handler{svc: svc}
 }
+
+var _ ServiceContract = (*Service)(nil)
 
 // GetRoutes declares the RBAC management endpoints.
 func (h *Handler) GetRoutes() feature.ModuleRoutes {

--- a/internal/rbac/handler_test.go
+++ b/internal/rbac/handler_test.go
@@ -1,0 +1,615 @@
+package rbac
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/Jayleonc/service/pkg/ginx/response"
+)
+
+// mockService 模拟服务层响应，便于验证 Handler 行为。
+type mockService struct {
+	mock.Mock
+}
+
+func (m *mockService) CreateRole(ctx context.Context, input CreateRoleInput) (*Role, error) {
+	args := m.Called(ctx, input)
+	role, _ := args.Get(0).(*Role)
+	return role, args.Error(1)
+}
+
+func (m *mockService) UpdateRole(ctx context.Context, input UpdateRoleInput) (*Role, error) {
+	args := m.Called(ctx, input)
+	role, _ := args.Get(0).(*Role)
+	return role, args.Error(1)
+}
+
+func (m *mockService) DeleteRole(ctx context.Context, input DeleteRoleInput) error {
+	args := m.Called(ctx, input)
+	return args.Error(0)
+}
+
+func (m *mockService) ListRoles(ctx context.Context) ([]Role, error) {
+	args := m.Called(ctx)
+	roles, _ := args.Get(0).([]Role)
+	return roles, args.Error(1)
+}
+
+func (m *mockService) AssignPermissions(ctx context.Context, input AssignRolePermissionsInput) (*Role, error) {
+	args := m.Called(ctx, input)
+	role, _ := args.Get(0).(*Role)
+	return role, args.Error(1)
+}
+
+func (m *mockService) GetRolePermissions(ctx context.Context, roleID uuid.UUID) ([]string, error) {
+	args := m.Called(ctx, roleID)
+	perms, _ := args.Get(0).([]string)
+	return perms, args.Error(1)
+}
+
+func (m *mockService) CreatePermission(ctx context.Context, input CreatePermissionInput) (*Permission, error) {
+	args := m.Called(ctx, input)
+	permission, _ := args.Get(0).(*Permission)
+	return permission, args.Error(1)
+}
+
+func (m *mockService) UpdatePermission(ctx context.Context, input UpdatePermissionInput) (*Permission, error) {
+	args := m.Called(ctx, input)
+	permission, _ := args.Get(0).(*Permission)
+	return permission, args.Error(1)
+}
+
+func (m *mockService) DeletePermission(ctx context.Context, input DeletePermissionInput) error {
+	args := m.Called(ctx, input)
+	return args.Error(0)
+}
+
+func (m *mockService) ListPermissions(ctx context.Context) ([]Permission, error) {
+	args := m.Called(ctx)
+	permissions, _ := args.Get(0).([]Permission)
+	return permissions, args.Error(1)
+}
+
+func newTestRouter(svc ServiceContract) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler := &Handler{svc: svc}
+	router.POST("/v1/rbac/role/create", handler.createRole)
+	router.POST("/v1/rbac/role/update", handler.updateRole)
+	router.POST("/v1/rbac/role/delete", handler.deleteRole)
+	router.POST("/v1/rbac/role/list", handler.listRoles)
+	router.POST("/v1/rbac/role/assign_permissions", handler.assignRolePermissions)
+	router.POST("/v1/rbac/role/get_permissions", handler.getRolePermissions)
+	router.POST("/v1/rbac/permission/create", handler.createPermission)
+	router.POST("/v1/rbac/permission/update", handler.updatePermission)
+	router.POST("/v1/rbac/permission/delete", handler.deletePermission)
+	router.POST("/v1/rbac/permission/list", handler.listPermissions)
+	return router
+}
+
+func performJSONRequest(t *testing.T, router *gin.Engine, method, path string, payload any) *httptest.ResponseRecorder {
+	t.Helper()
+
+	var body []byte
+	var err error
+	if payload != nil {
+		body, err = json.Marshal(payload)
+		require.NoError(t, err)
+	}
+	req, err := http.NewRequest(method, path, bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+	return recorder
+}
+
+func decodeResponse(t *testing.T, recorder *httptest.ResponseRecorder) response.Response {
+	t.Helper()
+
+	var resp response.Response
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp))
+	return resp
+}
+
+// TestHandlerCreateRole 覆盖角色创建接口的响应行为。
+func TestHandlerCreateRole(t *testing.T) {
+	cases := []struct {
+		name       string
+		payload    any
+		prepare    func(*mockService)
+		wantStatus int
+	}{
+		{
+			name: "创建成功",
+			payload: gin.H{
+				"name":        "editor",
+				"description": "内容编辑",
+			},
+			prepare: func(m *mockService) {
+				m.On("CreateRole", mock.Anything, CreateRoleInput{Name: "editor", Description: "内容编辑"}).Return(&Role{Name: "EDITOR"}, nil)
+			},
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name:       "参数缺失",
+			payload:    gin.H{"description": ""},
+			prepare:    func(m *mockService) {},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:    "业务错误",
+			payload: gin.H{"name": "editor"},
+			prepare: func(m *mockService) {
+				m.On("CreateRole", mock.Anything, CreateRoleInput{Name: "editor", Description: ""}).Return(nil, errors.New("failed"))
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &mockService{}
+			tc.prepare(svc)
+			router := newTestRouter(svc)
+
+			recorder := performJSONRequest(t, router, http.MethodPost, "/v1/rbac/role/create", tc.payload)
+			require.Equal(t, tc.wantStatus, recorder.Code)
+			if recorder.Code == http.StatusCreated {
+				resp := decodeResponse(t, recorder)
+				require.Equal(t, 0, resp.Code)
+			}
+			svc.AssertExpectations(t)
+		})
+	}
+}
+
+// TestHandlerUpdateRole 验证角色更新接口的输入校验和错误映射。
+func TestHandlerUpdateRole(t *testing.T) {
+	roleID := uuid.New()
+	name := "manager"
+	desc := "运营负责人"
+	cases := []struct {
+		name       string
+		payload    any
+		prepare    func(*mockService)
+		wantStatus int
+	}{
+		{
+			name: "更新成功",
+			payload: gin.H{
+				"id":          roleID.String(),
+				"name":        name,
+				"description": desc,
+			},
+			prepare: func(m *mockService) {
+				input := UpdateRoleInput{ID: roleID, Name: &name, Description: &desc}
+				m.On("UpdateRole", mock.Anything, input).Return(&Role{ID: roleID, Name: "MANAGER"}, nil)
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "无效 UUID",
+			payload:    gin.H{"id": "bad"},
+			prepare:    func(m *mockService) {},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:    "资源不存在",
+			payload: gin.H{"id": roleID.String()},
+			prepare: func(m *mockService) {
+				input := UpdateRoleInput{ID: roleID}
+				m.On("UpdateRole", mock.Anything, input).Return(nil, gorm.ErrRecordNotFound)
+			},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:    "业务失败",
+			payload: gin.H{"id": roleID.String()},
+			prepare: func(m *mockService) {
+				input := UpdateRoleInput{ID: roleID}
+				m.On("UpdateRole", mock.Anything, input).Return(nil, errors.New("failed"))
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &mockService{}
+			tc.prepare(svc)
+			router := newTestRouter(svc)
+
+			recorder := performJSONRequest(t, router, http.MethodPost, "/v1/rbac/role/update", tc.payload)
+			require.Equal(t, tc.wantStatus, recorder.Code)
+			svc.AssertExpectations(t)
+		})
+	}
+}
+
+// TestHandlerDeleteRole 验证角色删除接口的分支。
+func TestHandlerDeleteRole(t *testing.T) {
+	roleID := uuid.New()
+	cases := []struct {
+		name       string
+		payload    any
+		prepare    func(*mockService)
+		wantStatus int
+	}{
+		{
+			name:       "删除成功",
+			payload:    gin.H{"id": roleID.String()},
+			prepare:    func(m *mockService) { m.On("DeleteRole", mock.Anything, DeleteRoleInput{ID: roleID}).Return(nil) },
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "无效参数",
+			payload:    gin.H{},
+			prepare:    func(m *mockService) {},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:    "资源不存在",
+			payload: gin.H{"id": roleID.String()},
+			prepare: func(m *mockService) {
+				m.On("DeleteRole", mock.Anything, DeleteRoleInput{ID: roleID}).Return(gorm.ErrRecordNotFound)
+			},
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &mockService{}
+			tc.prepare(svc)
+			router := newTestRouter(svc)
+
+			recorder := performJSONRequest(t, router, http.MethodPost, "/v1/rbac/role/delete", tc.payload)
+			require.Equal(t, tc.wantStatus, recorder.Code)
+			svc.AssertExpectations(t)
+		})
+	}
+}
+
+// TestHandlerListRoles 确认角色列表接口的返回内容。
+func TestHandlerListRoles(t *testing.T) {
+	cases := []struct {
+		name       string
+		prepare    func(*mockService)
+		wantStatus int
+		wantCount  int
+	}{
+		{
+			name: "成功返回",
+			prepare: func(m *mockService) {
+				m.On("ListRoles", mock.Anything).Return([]Role{{Name: "ADMIN"}}, nil)
+			},
+			wantStatus: http.StatusOK,
+			wantCount:  1,
+		},
+		{
+			name:       "服务错误",
+			prepare:    func(m *mockService) { m.On("ListRoles", mock.Anything).Return(nil, errors.New("failed")) },
+			wantStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &mockService{}
+			tc.prepare(svc)
+			router := newTestRouter(svc)
+
+			recorder := performJSONRequest(t, router, http.MethodPost, "/v1/rbac/role/list", gin.H{})
+			require.Equal(t, tc.wantStatus, recorder.Code)
+			if recorder.Code == http.StatusOK {
+				resp := decodeResponse(t, recorder)
+				roles, ok := resp.Data.([]any)
+				if !ok {
+					raw, err := json.Marshal(resp.Data)
+					require.NoError(t, err)
+					require.NoError(t, json.Unmarshal(raw, &roles))
+				}
+				require.Len(t, roles, tc.wantCount)
+			}
+			svc.AssertExpectations(t)
+		})
+	}
+}
+
+// TestHandlerAssignRolePermissions 检查权限分配接口的返回。
+func TestHandlerAssignRolePermissions(t *testing.T) {
+	roleID := uuid.New()
+	cases := []struct {
+		name       string
+		payload    any
+		prepare    func(*mockService)
+		wantStatus int
+	}{
+		{
+			name: "分配成功",
+			payload: gin.H{
+				"roleId":      roleID.String(),
+				"permissions": []string{"system:view"},
+			},
+			prepare: func(m *mockService) {
+				input := AssignRolePermissionsInput{RoleID: roleID, Permissions: []string{"system:view"}}
+				m.On("AssignPermissions", mock.Anything, input).Return(&Role{ID: roleID}, nil)
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "参数缺失",
+			payload:    gin.H{"roleId": roleID.String()},
+			prepare:    func(m *mockService) {},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:    "角色缺失",
+			payload: gin.H{"roleId": roleID.String(), "permissions": []string{"system:view"}},
+			prepare: func(m *mockService) {
+				input := AssignRolePermissionsInput{RoleID: roleID, Permissions: []string{"system:view"}}
+				m.On("AssignPermissions", mock.Anything, input).Return(nil, gorm.ErrRecordNotFound)
+			},
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &mockService{}
+			tc.prepare(svc)
+			router := newTestRouter(svc)
+
+			recorder := performJSONRequest(t, router, http.MethodPost, "/v1/rbac/role/assign_permissions", tc.payload)
+			require.Equal(t, tc.wantStatus, recorder.Code)
+			svc.AssertExpectations(t)
+		})
+	}
+}
+
+// TestHandlerGetRolePermissions 覆盖角色权限查询接口。
+func TestHandlerGetRolePermissions(t *testing.T) {
+	roleID := uuid.New()
+	cases := []struct {
+		name       string
+		payload    any
+		prepare    func(*mockService)
+		wantStatus int
+	}{
+		{
+			name:    "查询成功",
+			payload: gin.H{"roleId": roleID.String()},
+			prepare: func(m *mockService) {
+				m.On("GetRolePermissions", mock.Anything, roleID).Return([]string{"system:view"}, nil)
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "缺少参数",
+			payload:    gin.H{},
+			prepare:    func(m *mockService) {},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:    "角色不存在",
+			payload: gin.H{"roleId": roleID.String()},
+			prepare: func(m *mockService) {
+				m.On("GetRolePermissions", mock.Anything, roleID).Return(nil, gorm.ErrRecordNotFound)
+			},
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &mockService{}
+			tc.prepare(svc)
+			router := newTestRouter(svc)
+
+			recorder := performJSONRequest(t, router, http.MethodPost, "/v1/rbac/role/get_permissions", tc.payload)
+			require.Equal(t, tc.wantStatus, recorder.Code)
+			svc.AssertExpectations(t)
+		})
+	}
+}
+
+// TestHandlerCreatePermission 验证权限创建接口。
+func TestHandlerCreatePermission(t *testing.T) {
+	cases := []struct {
+		name       string
+		payload    any
+		prepare    func(*mockService)
+		wantStatus int
+	}{
+		{
+			name:    "创建成功",
+			payload: gin.H{"resource": "system", "action": "view"},
+			prepare: func(m *mockService) {
+				input := CreatePermissionInput{Resource: "system", Action: "view"}
+				m.On("CreatePermission", mock.Anything, input).Return(&Permission{Resource: "system", Action: "view"}, nil)
+			},
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name:       "缺少字段",
+			payload:    gin.H{"resource": "system"},
+			prepare:    func(m *mockService) {},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:    "业务错误",
+			payload: gin.H{"resource": "system", "action": "view"},
+			prepare: func(m *mockService) {
+				input := CreatePermissionInput{Resource: "system", Action: "view"}
+				m.On("CreatePermission", mock.Anything, input).Return(nil, errors.New("failed"))
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &mockService{}
+			tc.prepare(svc)
+			router := newTestRouter(svc)
+
+			recorder := performJSONRequest(t, router, http.MethodPost, "/v1/rbac/permission/create", tc.payload)
+			require.Equal(t, tc.wantStatus, recorder.Code)
+			svc.AssertExpectations(t)
+		})
+	}
+}
+
+// TestHandlerUpdatePermission 验证权限更新接口。
+func TestHandlerUpdatePermission(t *testing.T) {
+	permissionID := uuid.New()
+	resource := "system"
+	cases := []struct {
+		name       string
+		payload    any
+		prepare    func(*mockService)
+		wantStatus int
+	}{
+		{
+			name:    "更新成功",
+			payload: gin.H{"id": permissionID.String(), "resource": resource},
+			prepare: func(m *mockService) {
+				input := UpdatePermissionInput{ID: permissionID, Resource: &resource}
+				m.On("UpdatePermission", mock.Anything, input).Return(&Permission{ID: permissionID}, nil)
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "无效 UUID",
+			payload:    gin.H{"id": "bad"},
+			prepare:    func(m *mockService) {},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:    "未找到",
+			payload: gin.H{"id": permissionID.String()},
+			prepare: func(m *mockService) {
+				input := UpdatePermissionInput{ID: permissionID}
+				m.On("UpdatePermission", mock.Anything, input).Return(nil, gorm.ErrRecordNotFound)
+			},
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &mockService{}
+			tc.prepare(svc)
+			router := newTestRouter(svc)
+
+			recorder := performJSONRequest(t, router, http.MethodPost, "/v1/rbac/permission/update", tc.payload)
+			require.Equal(t, tc.wantStatus, recorder.Code)
+			svc.AssertExpectations(t)
+		})
+	}
+}
+
+// TestHandlerDeletePermission 验证权限删除接口。
+func TestHandlerDeletePermission(t *testing.T) {
+	permissionID := uuid.New()
+	cases := []struct {
+		name       string
+		payload    any
+		prepare    func(*mockService)
+		wantStatus int
+	}{
+		{
+			name:    "删除成功",
+			payload: gin.H{"id": permissionID.String()},
+			prepare: func(m *mockService) {
+				m.On("DeletePermission", mock.Anything, DeletePermissionInput{ID: permissionID}).Return(nil)
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "缺少参数",
+			payload:    gin.H{},
+			prepare:    func(m *mockService) {},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:    "未找到",
+			payload: gin.H{"id": permissionID.String()},
+			prepare: func(m *mockService) {
+				m.On("DeletePermission", mock.Anything, DeletePermissionInput{ID: permissionID}).Return(gorm.ErrRecordNotFound)
+			},
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &mockService{}
+			tc.prepare(svc)
+			router := newTestRouter(svc)
+
+			recorder := performJSONRequest(t, router, http.MethodPost, "/v1/rbac/permission/delete", tc.payload)
+			require.Equal(t, tc.wantStatus, recorder.Code)
+			svc.AssertExpectations(t)
+		})
+	}
+}
+
+// TestHandlerListPermissions 检查权限列表接口。
+func TestHandlerListPermissions(t *testing.T) {
+	cases := []struct {
+		name       string
+		prepare    func(*mockService)
+		wantStatus int
+		wantCount  int
+	}{
+		{
+			name: "返回列表",
+			prepare: func(m *mockService) {
+				m.On("ListPermissions", mock.Anything).Return([]Permission{{Resource: "system", Action: "view"}}, nil)
+			},
+			wantStatus: http.StatusOK,
+			wantCount:  1,
+		},
+		{
+			name:       "服务错误",
+			prepare:    func(m *mockService) { m.On("ListPermissions", mock.Anything).Return(nil, errors.New("failed")) },
+			wantStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &mockService{}
+			tc.prepare(svc)
+			router := newTestRouter(svc)
+
+			recorder := performJSONRequest(t, router, http.MethodPost, "/v1/rbac/permission/list", gin.H{})
+			require.Equal(t, tc.wantStatus, recorder.Code)
+			if recorder.Code == http.StatusOK {
+				resp := decodeResponse(t, recorder)
+				permissions, ok := resp.Data.([]any)
+				if !ok {
+					raw, err := json.Marshal(resp.Data)
+					require.NoError(t, err)
+					require.NoError(t, json.Unmarshal(raw, &permissions))
+				}
+				require.Len(t, permissions, tc.wantCount)
+			}
+			svc.AssertExpectations(t)
+		})
+	}
+}

--- a/internal/rbac/middleware_test.go
+++ b/internal/rbac/middleware_test.go
@@ -1,0 +1,108 @@
+package rbac
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Jayleonc/service/internal/feature"
+	"github.com/Jayleonc/service/pkg/constant"
+	"github.com/Jayleonc/service/pkg/ginx/response"
+)
+
+// mockPermissionChecker 模拟权限校验器行为。
+type mockPermissionChecker struct {
+	mock.Mock
+}
+
+func (m *mockPermissionChecker) HasPermission(ctx context.Context, userID uuid.UUID, permission string) (bool, error) {
+	args := m.Called(ctx, userID, permission)
+	allowed, _ := args.Get(0).(bool)
+	return allowed, args.Error(1)
+}
+
+// TestPermissionMiddleware 验证权限中间件的三种关键场景。
+func TestPermissionMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	permissionKey := "system:view"
+
+	cases := []struct {
+		name       string
+		session    *feature.AuthContext
+		prepare    func(*mockPermissionChecker)
+		wantStatus int
+		expectCall bool
+	}{
+		{
+			name: "普通用户拥有权限",
+			session: &feature.AuthContext{
+				UserID: uuid.New(),
+				Roles:  []string{"user"},
+			},
+			prepare: func(m *mockPermissionChecker) {
+				m.On("HasPermission", mock.Anything, mock.Anything, permissionKey).Return(true, nil)
+			},
+			wantStatus: http.StatusOK,
+			expectCall: true,
+		},
+		{
+			name: "权限不足被拒绝",
+			session: &feature.AuthContext{
+				UserID: uuid.New(),
+				Roles:  []string{"user"},
+			},
+			prepare: func(m *mockPermissionChecker) {
+				m.On("HasPermission", mock.Anything, mock.Anything, permissionKey).Return(false, nil)
+			},
+			wantStatus: http.StatusForbidden,
+			expectCall: true,
+		},
+		{
+			name: "管理员直接放行",
+			session: &feature.AuthContext{
+				UserID: uuid.New(),
+				Roles:  []string{constant.RoleAdmin},
+			},
+			prepare:    func(m *mockPermissionChecker) {},
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			checker := &mockPermissionChecker{}
+			tc.prepare(checker)
+
+			middlewareFactory := NewPermissionMiddleware(checker)
+			require.NotNil(t, middlewareFactory)
+
+			router := gin.New()
+			router.Use(func(c *gin.Context) {
+				if tc.session != nil {
+					feature.SetAuthContext(c, *tc.session)
+				}
+			})
+			router.GET("/protected", middlewareFactory(permissionKey), func(c *gin.Context) {
+				response.Success(c, gin.H{"ok": true})
+			})
+
+			req, err := http.NewRequest(http.MethodGet, "/protected", nil)
+			require.NoError(t, err)
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(recorder, req)
+
+			require.Equal(t, tc.wantStatus, recorder.Code)
+			if tc.expectCall {
+				checker.AssertCalled(t, "HasPermission", mock.Anything, tc.session.UserID, permissionKey)
+			} else {
+				checker.AssertNotCalled(t, "HasPermission", mock.Anything, mock.Anything, permissionKey)
+			}
+		})
+	}
+}

--- a/internal/rbac/repository_test.go
+++ b/internal/rbac/repository_test.go
@@ -1,0 +1,317 @@
+package rbac
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// userRole 用于构造 user_roles 关联表，满足 UserHasPermission 查询需求。
+type userRole struct {
+	UserID uuid.UUID `gorm:"type:uuid"`
+	RoleID uuid.UUID `gorm:"type:uuid"`
+}
+
+func (userRole) TableName() string {
+	return "user_roles"
+}
+
+// setupTestDB 创建独立的内存数据库并初始化基础结构。
+func setupTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+
+	require.NoError(t, db.Exec("PRAGMA foreign_keys = ON").Error)
+
+	repo := NewRepository(db)
+	require.NoError(t, repo.Migrate(context.Background()))
+	require.NoError(t, db.AutoMigrate(&userRole{}))
+	return db
+}
+
+// runInTransaction 在事务中执行测试逻辑，并在结束后自动回滚。
+func runInTransaction(t *testing.T, db *gorm.DB, fn func(ctx context.Context, repo *Repository, tx *gorm.DB)) {
+	t.Helper()
+
+	tx := db.Begin()
+	require.NoError(t, tx.Error)
+
+	t.Cleanup(func() {
+		require.NoError(t, tx.Rollback().Error)
+	})
+
+	fn(context.Background(), NewRepository(tx), tx)
+}
+
+// TestRepositoryCreateRole 验证 CreateRole 能够持久化角色信息。
+func TestRepositoryCreateRole(t *testing.T) {
+	db := setupTestDB(t)
+
+	runInTransaction(t, db, func(ctx context.Context, repo *Repository, tx *gorm.DB) {
+		role := &Role{ID: uuid.New(), Name: "ADMIN", Description: "超级管理员"}
+		require.NoError(t, repo.CreateRole(ctx, role))
+
+		var stored Role
+		require.NoError(t, tx.WithContext(ctx).First(&stored, "id = ?", role.ID).Error)
+		require.Equal(t, role.Name, stored.Name)
+		require.Equal(t, role.Description, stored.Description)
+	})
+}
+
+// TestRepositoryUpdateRole 验证 UpdateRole 可以更新角色字段。
+func TestRepositoryUpdateRole(t *testing.T) {
+	db := setupTestDB(t)
+
+	runInTransaction(t, db, func(ctx context.Context, repo *Repository, tx *gorm.DB) {
+		original := &Role{ID: uuid.New(), Name: "USER", Description: "普通用户"}
+		require.NoError(t, tx.WithContext(ctx).Create(original).Error)
+
+		original.Description = "高级用户"
+		require.NoError(t, repo.UpdateRole(ctx, original))
+
+		var stored Role
+		require.NoError(t, tx.WithContext(ctx).First(&stored, "id = ?", original.ID).Error)
+		require.Equal(t, "高级用户", stored.Description)
+	})
+}
+
+// TestRepositoryDeleteRole 确认 DeleteRole 会删除角色以及角色权限关系。
+func TestRepositoryDeleteRole(t *testing.T) {
+	db := setupTestDB(t)
+
+	runInTransaction(t, db, func(ctx context.Context, repo *Repository, tx *gorm.DB) {
+		perm := &Permission{ID: uuid.New(), Resource: "rbac", Action: "view"}
+		role := &Role{ID: uuid.New(), Name: "AUDITOR"}
+		require.NoError(t, tx.WithContext(ctx).Create(perm).Error)
+		require.NoError(t, tx.WithContext(ctx).Create(role).Error)
+		require.NoError(t, tx.WithContext(ctx).Model(role).Association("Permissions").Append(perm))
+
+		require.NoError(t, repo.DeleteRole(ctx, role.ID))
+
+		var count int64
+		require.NoError(t, tx.WithContext(ctx).Model(&Role{}).Where("id = ?", role.ID).Count(&count).Error)
+		require.Zero(t, count)
+
+		var relCount int64
+		require.NoError(t, tx.WithContext(ctx).Table("role_permissions").Where("role_id = ?", role.ID).Count(&relCount).Error)
+		require.Zero(t, relCount)
+	})
+}
+
+// TestRepositoryListRoles 校验 ListRoles 能够按时间顺序返回包含权限的角色集合。
+func TestRepositoryListRoles(t *testing.T) {
+	db := setupTestDB(t)
+
+	runInTransaction(t, db, func(ctx context.Context, repo *Repository, tx *gorm.DB) {
+		permissions := []*Permission{
+			{ID: uuid.New(), Resource: "rbac", Action: "create"},
+			{ID: uuid.New(), Resource: "rbac", Action: "delete"},
+		}
+		for _, p := range permissions {
+			require.NoError(t, tx.WithContext(ctx).Create(p).Error)
+		}
+
+		roles := []*Role{
+			{ID: uuid.New(), Name: "ADMIN", Permissions: []*Permission{permissions[0], permissions[1]}},
+			{ID: uuid.New(), Name: "USER", Permissions: []*Permission{permissions[0]}},
+		}
+		for _, r := range roles {
+			require.NoError(t, tx.WithContext(ctx).Create(r).Error)
+			require.NoError(t, tx.WithContext(ctx).Model(r).Association("Permissions").Append(r.Permissions))
+		}
+
+		result, err := repo.ListRoles(ctx)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		require.NotEmpty(t, result[0].Permissions)
+	})
+}
+
+// TestRepositoryFindRoleByID 验证可以通过主键精确查找角色。
+func TestRepositoryFindRoleByID(t *testing.T) {
+	db := setupTestDB(t)
+
+	runInTransaction(t, db, func(ctx context.Context, repo *Repository, tx *gorm.DB) {
+		role := &Role{ID: uuid.New(), Name: "OPERATOR"}
+		require.NoError(t, tx.WithContext(ctx).Create(role).Error)
+
+		stored, err := repo.FindRoleByID(ctx, role.ID)
+		require.NoError(t, err)
+		require.Equal(t, role.ID, stored.ID)
+	})
+}
+
+// TestRepositoryFindRoleByName 验证可以通过名称查找角色。
+func TestRepositoryFindRoleByName(t *testing.T) {
+	db := setupTestDB(t)
+
+	runInTransaction(t, db, func(ctx context.Context, repo *Repository, tx *gorm.DB) {
+		role := &Role{ID: uuid.New(), Name: "SUPPORT"}
+		require.NoError(t, tx.WithContext(ctx).Create(role).Error)
+
+		stored, err := repo.FindRoleByName(ctx, role.Name)
+		require.NoError(t, err)
+		require.Equal(t, role.Name, stored.Name)
+	})
+}
+
+// TestRepositoryFindRolesByNames 覆盖批量查询并保证输入正规化。
+func TestRepositoryFindRolesByNames(t *testing.T) {
+	db := setupTestDB(t)
+
+	runInTransaction(t, db, func(ctx context.Context, repo *Repository, tx *gorm.DB) {
+		roleA := &Role{ID: uuid.New(), Name: "ADMIN"}
+		roleB := &Role{ID: uuid.New(), Name: "USER"}
+		require.NoError(t, tx.WithContext(ctx).Create(roleA).Error)
+		require.NoError(t, tx.WithContext(ctx).Create(roleB).Error)
+
+		roles, err := repo.FindRolesByNames(ctx, []string{" admin ", "user", ""})
+		require.NoError(t, err)
+		require.Len(t, roles, 2)
+	})
+}
+
+// TestRepositoryCreatePermission 验证 CreatePermission 能够写入权限。
+func TestRepositoryCreatePermission(t *testing.T) {
+	db := setupTestDB(t)
+
+	runInTransaction(t, db, func(ctx context.Context, repo *Repository, tx *gorm.DB) {
+		permission := &Permission{ID: uuid.New(), Resource: "system", Action: "list"}
+		require.NoError(t, repo.CreatePermission(ctx, permission))
+
+		var stored Permission
+		require.NoError(t, tx.WithContext(ctx).First(&stored, "id = ?", permission.ID).Error)
+		require.Equal(t, permission.Resource, stored.Resource)
+	})
+}
+
+// TestRepositoryUpdatePermission 确保 UpdatePermission 会更新权限信息。
+func TestRepositoryUpdatePermission(t *testing.T) {
+	db := setupTestDB(t)
+
+	runInTransaction(t, db, func(ctx context.Context, repo *Repository, tx *gorm.DB) {
+		permission := &Permission{ID: uuid.New(), Resource: "system", Action: "view"}
+		require.NoError(t, tx.WithContext(ctx).Create(permission).Error)
+
+		permission.Description = "查看系统"
+		require.NoError(t, repo.UpdatePermission(ctx, permission))
+
+		var stored Permission
+		require.NoError(t, tx.WithContext(ctx).First(&stored, "id = ?", permission.ID).Error)
+		require.Equal(t, "查看系统", stored.Description)
+	})
+}
+
+// TestRepositoryDeletePermission 验证 DeletePermission 会删除记录。
+func TestRepositoryDeletePermission(t *testing.T) {
+	db := setupTestDB(t)
+
+	runInTransaction(t, db, func(ctx context.Context, repo *Repository, tx *gorm.DB) {
+		permission := &Permission{ID: uuid.New(), Resource: "system", Action: "delete"}
+		require.NoError(t, tx.WithContext(ctx).Create(permission).Error)
+
+		require.NoError(t, repo.DeletePermission(ctx, permission.ID))
+
+		var count int64
+		require.NoError(t, tx.WithContext(ctx).Model(&Permission{}).Where("id = ?", permission.ID).Count(&count).Error)
+		require.Zero(t, count)
+	})
+}
+
+// TestRepositoryListPermissions 校验 ListPermissions 返回全部权限。
+func TestRepositoryListPermissions(t *testing.T) {
+	db := setupTestDB(t)
+
+	runInTransaction(t, db, func(ctx context.Context, repo *Repository, tx *gorm.DB) {
+		permissions := []Permission{
+			{ID: uuid.New(), Resource: "system", Action: "create"},
+			{ID: uuid.New(), Resource: "system", Action: "view"},
+		}
+		require.NoError(t, tx.WithContext(ctx).Create(&permissions).Error)
+
+		result, err := repo.ListPermissions(ctx)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+	})
+}
+
+// TestRepositoryFindPermissionByID 验证主键查询权限。
+func TestRepositoryFindPermissionByID(t *testing.T) {
+	db := setupTestDB(t)
+
+	runInTransaction(t, db, func(ctx context.Context, repo *Repository, tx *gorm.DB) {
+		permission := &Permission{ID: uuid.New(), Resource: "system", Action: "update"}
+		require.NoError(t, tx.WithContext(ctx).Create(permission).Error)
+
+		stored, err := repo.FindPermissionByID(ctx, permission.ID)
+		require.NoError(t, err)
+		require.Equal(t, permission.ID, stored.ID)
+	})
+}
+
+// TestRepositoryFindPermissionsByKeys 验证通过组合键批量查找权限。
+func TestRepositoryFindPermissionsByKeys(t *testing.T) {
+	db := setupTestDB(t)
+
+	runInTransaction(t, db, func(ctx context.Context, repo *Repository, tx *gorm.DB) {
+		permissions := []Permission{
+			{ID: uuid.New(), Resource: "system", Action: "create"},
+			{ID: uuid.New(), Resource: "system", Action: "delete"},
+		}
+		require.NoError(t, tx.WithContext(ctx).Create(&permissions).Error)
+
+		result, err := repo.FindPermissionsByKeys(ctx, []string{"system:create", "system:delete", "invalid"})
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+	})
+}
+
+// TestRepositoryReplaceRolePermissions 确认 ReplaceRolePermissions 可以重建关联。
+func TestRepositoryReplaceRolePermissions(t *testing.T) {
+	db := setupTestDB(t)
+
+	runInTransaction(t, db, func(ctx context.Context, repo *Repository, tx *gorm.DB) {
+		role := &Role{ID: uuid.New(), Name: "EDITOR"}
+		oldPermission := &Permission{ID: uuid.New(), Resource: "article", Action: "edit"}
+		newPermission := &Permission{ID: uuid.New(), Resource: "article", Action: "publish"}
+		require.NoError(t, tx.WithContext(ctx).Create(role).Error)
+		require.NoError(t, tx.WithContext(ctx).Create(oldPermission).Error)
+		require.NoError(t, tx.WithContext(ctx).Create(newPermission).Error)
+		require.NoError(t, tx.WithContext(ctx).Model(role).Association("Permissions").Append(oldPermission))
+
+		require.NoError(t, repo.ReplaceRolePermissions(ctx, role, []*Permission{newPermission}))
+
+		var relCount int64
+		require.NoError(t, tx.WithContext(ctx).Table("role_permissions").Where("role_id = ? AND permission_id = ?", role.ID, newPermission.ID).Count(&relCount).Error)
+		require.EqualValues(t, 1, relCount)
+	})
+}
+
+// TestRepositoryUserHasPermission 覆盖用户权限判断逻辑。
+func TestRepositoryUserHasPermission(t *testing.T) {
+	db := setupTestDB(t)
+
+	runInTransaction(t, db, func(ctx context.Context, repo *Repository, tx *gorm.DB) {
+		userID := uuid.New()
+		role := &Role{ID: uuid.New(), Name: "REVIEWER"}
+		permission := &Permission{ID: uuid.New(), Resource: "article", Action: "approve"}
+		require.NoError(t, tx.WithContext(ctx).Create(role).Error)
+		require.NoError(t, tx.WithContext(ctx).Create(permission).Error)
+		require.NoError(t, tx.WithContext(ctx).Model(role).Association("Permissions").Append(permission))
+		require.NoError(t, tx.WithContext(ctx).Create(&userRole{UserID: userID, RoleID: role.ID}).Error)
+
+		allowed, err := repo.UserHasPermission(ctx, userID, PermissionKey("article", "approve"))
+		require.NoError(t, err)
+		require.True(t, allowed)
+
+		denied, err := repo.UserHasPermission(ctx, userID, "invalid")
+		require.NoError(t, err)
+		require.False(t, denied)
+	})
+}

--- a/internal/rbac/service.go
+++ b/internal/rbac/service.go
@@ -13,9 +13,29 @@ import (
 	"github.com/Jayleonc/service/pkg/constant"
 )
 
+// RepositoryContract 定义了 Service 赖以运作的仓储能力。
+type RepositoryContract interface {
+	Migrate(ctx context.Context) error
+	CreateRole(ctx context.Context, role *Role) error
+	UpdateRole(ctx context.Context, role *Role) error
+	DeleteRole(ctx context.Context, id uuid.UUID) error
+	ListRoles(ctx context.Context) ([]Role, error)
+	FindRoleByID(ctx context.Context, id uuid.UUID) (*Role, error)
+	FindRoleByName(ctx context.Context, name string) (*Role, error)
+	FindRolesByNames(ctx context.Context, names []string) ([]*Role, error)
+	CreatePermission(ctx context.Context, permission *Permission) error
+	UpdatePermission(ctx context.Context, permission *Permission) error
+	DeletePermission(ctx context.Context, id uuid.UUID) error
+	ListPermissions(ctx context.Context) ([]Permission, error)
+	FindPermissionByID(ctx context.Context, id uuid.UUID) (*Permission, error)
+	FindPermissionsByKeys(ctx context.Context, keys []string) ([]*Permission, error)
+	ReplaceRolePermissions(ctx context.Context, role *Role, permissions []*Permission) error
+	UserHasPermission(ctx context.Context, userID uuid.UUID, permission string) (bool, error)
+}
+
 // Service orchestrates RBAC operations.
 type Service struct {
-	repo *Repository
+	repo RepositoryContract
 }
 
 var (
@@ -41,6 +61,8 @@ func DefaultService() *Service {
 func NewService(repo *Repository) *Service {
 	return &Service{repo: repo}
 }
+
+var _ RepositoryContract = (*Repository)(nil)
 
 // EnsureService initialises the default service instance if it has not been created yet.
 func EnsureService(ctx context.Context, repo *Repository) (*Service, error) {

--- a/internal/rbac/service_test.go
+++ b/internal/rbac/service_test.go
@@ -1,0 +1,854 @@
+package rbac
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/Jayleonc/service/pkg/constant"
+)
+
+// mockRepository 使用 testify 模拟仓储层行为。
+type mockRepository struct {
+	mock.Mock
+}
+
+func (m *mockRepository) Migrate(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *mockRepository) CreateRole(ctx context.Context, role *Role) error {
+	args := m.Called(ctx, role)
+	return args.Error(0)
+}
+
+func (m *mockRepository) UpdateRole(ctx context.Context, role *Role) error {
+	args := m.Called(ctx, role)
+	return args.Error(0)
+}
+
+func (m *mockRepository) DeleteRole(ctx context.Context, id uuid.UUID) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+func (m *mockRepository) ListRoles(ctx context.Context) ([]Role, error) {
+	args := m.Called(ctx)
+	roles, _ := args.Get(0).([]Role)
+	return roles, args.Error(1)
+}
+
+func (m *mockRepository) FindRoleByID(ctx context.Context, id uuid.UUID) (*Role, error) {
+	args := m.Called(ctx, id)
+	role, _ := args.Get(0).(*Role)
+	return role, args.Error(1)
+}
+
+func (m *mockRepository) FindRoleByName(ctx context.Context, name string) (*Role, error) {
+	args := m.Called(ctx, name)
+	role, _ := args.Get(0).(*Role)
+	return role, args.Error(1)
+}
+
+func (m *mockRepository) FindRolesByNames(ctx context.Context, names []string) ([]*Role, error) {
+	args := m.Called(ctx, names)
+	roles, _ := args.Get(0).([]*Role)
+	return roles, args.Error(1)
+}
+
+func (m *mockRepository) CreatePermission(ctx context.Context, permission *Permission) error {
+	args := m.Called(ctx, permission)
+	return args.Error(0)
+}
+
+func (m *mockRepository) UpdatePermission(ctx context.Context, permission *Permission) error {
+	args := m.Called(ctx, permission)
+	return args.Error(0)
+}
+
+func (m *mockRepository) DeletePermission(ctx context.Context, id uuid.UUID) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+func (m *mockRepository) ListPermissions(ctx context.Context) ([]Permission, error) {
+	args := m.Called(ctx)
+	perms, _ := args.Get(0).([]Permission)
+	return perms, args.Error(1)
+}
+
+func (m *mockRepository) FindPermissionByID(ctx context.Context, id uuid.UUID) (*Permission, error) {
+	args := m.Called(ctx, id)
+	permission, _ := args.Get(0).(*Permission)
+	return permission, args.Error(1)
+}
+
+func (m *mockRepository) FindPermissionsByKeys(ctx context.Context, keys []string) ([]*Permission, error) {
+	args := m.Called(ctx, keys)
+	permissions, _ := args.Get(0).([]*Permission)
+	return permissions, args.Error(1)
+}
+
+func (m *mockRepository) ReplaceRolePermissions(ctx context.Context, role *Role, permissions []*Permission) error {
+	args := m.Called(ctx, role, permissions)
+	return args.Error(0)
+}
+
+func (m *mockRepository) UserHasPermission(ctx context.Context, userID uuid.UUID, permission string) (bool, error) {
+	args := m.Called(ctx, userID, permission)
+	allowed, _ := args.Get(0).(bool)
+	return allowed, args.Error(1)
+}
+
+func newMockService(repo *mockRepository) *Service {
+	return &Service{repo: repo}
+}
+
+// TestServiceCreateRole 使用表驱动测试角色创建流程。
+func TestServiceCreateRole(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   CreateRoleInput
+		prepare func(*mockRepository)
+		wantErr bool
+	}{
+		{
+			name:  "成功创建并规范化名称",
+			input: CreateRoleInput{Name: "  manager ", Description: "业务管理员"},
+			prepare: func(m *mockRepository) {
+				m.On("CreateRole", mock.Anything, mock.MatchedBy(func(role *Role) bool {
+					return role.Name == "MANAGER" && role.Description == "业务管理员"
+				})).Return(nil)
+			},
+		},
+		{
+			name:    "缺失名称触发校验错误",
+			input:   CreateRoleInput{Name: "   "},
+			prepare: func(m *mockRepository) {},
+			wantErr: true,
+		},
+		{
+			name:  "仓储返回错误",
+			input: CreateRoleInput{Name: "auditor"},
+			prepare: func(m *mockRepository) {
+				m.On("CreateRole", mock.Anything, mock.AnythingOfType("*rbac.Role")).Return(errors.New("db"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockRepo := &mockRepository{}
+			if tc.prepare != nil {
+				tc.prepare(mockRepo)
+			}
+			svc := newMockService(mockRepo)
+
+			role, err := svc.CreateRole(context.Background(), tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Nil(t, role)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, role)
+			}
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}
+
+// TestServiceUpdateRole 覆盖角色更新的正常与异常路径。
+func TestServiceUpdateRole(t *testing.T) {
+	newName := " leader "
+	newDescription := "部门负责人"
+	cases := []struct {
+		name    string
+		input   UpdateRoleInput
+		prepare func(*mockRepository)
+		wantErr bool
+	}{
+		{
+			name: "成功更新字段",
+			input: UpdateRoleInput{
+				ID:          uuid.New(),
+				Name:        &newName,
+				Description: &newDescription,
+			},
+			prepare: func(m *mockRepository) {
+				existing := &Role{ID: uuid.New(), Name: "OLD", Description: "描述"}
+				m.On("FindRoleByID", mock.Anything, mock.Anything).Return(existing, nil)
+				m.On("UpdateRole", mock.Anything, mock.MatchedBy(func(role *Role) bool {
+					return role.Name == "LEADER" && role.Description == "部门负责人"
+				})).Return(nil)
+			},
+		},
+		{
+			name:  "空名称触发错误",
+			input: UpdateRoleInput{ID: uuid.New(), Name: func() *string { v := " "; return &v }()},
+			prepare: func(m *mockRepository) {
+				existing := &Role{ID: uuid.New(), Name: "OLD"}
+				m.On("FindRoleByID", mock.Anything, mock.Anything).Return(existing, nil)
+			},
+			wantErr: true,
+		},
+		{
+			name:  "查询失败",
+			input: UpdateRoleInput{ID: uuid.New()},
+			prepare: func(m *mockRepository) {
+				m.On("FindRoleByID", mock.Anything, mock.Anything).Return(nil, errors.New("db"))
+			},
+			wantErr: true,
+		},
+		{
+			name:  "保存失败",
+			input: UpdateRoleInput{ID: uuid.New()},
+			prepare: func(m *mockRepository) {
+				existing := &Role{ID: uuid.New(), Name: "OLD"}
+				m.On("FindRoleByID", mock.Anything, mock.Anything).Return(existing, nil)
+				m.On("UpdateRole", mock.Anything, mock.AnythingOfType("*rbac.Role")).Return(errors.New("db"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockRepo := &mockRepository{}
+			tc.prepare(mockRepo)
+			svc := newMockService(mockRepo)
+
+			role, err := svc.UpdateRole(context.Background(), tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Nil(t, role)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, role)
+			}
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}
+
+// TestServiceDeleteRole 验证删除逻辑能正确传递参数并处理错误。
+func TestServiceDeleteRole(t *testing.T) {
+	roleID := uuid.New()
+	cases := []struct {
+		name    string
+		prepare func(*mockRepository)
+		wantErr bool
+	}{
+		{
+			name: "删除成功",
+			prepare: func(m *mockRepository) {
+				m.On("DeleteRole", mock.Anything, roleID).Return(nil)
+			},
+		},
+		{
+			name: "删除失败返回错误",
+			prepare: func(m *mockRepository) {
+				m.On("DeleteRole", mock.Anything, roleID).Return(errors.New("db"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockRepo := &mockRepository{}
+			tc.prepare(mockRepo)
+			svc := newMockService(mockRepo)
+
+			err := svc.DeleteRole(context.Background(), DeleteRoleInput{ID: roleID})
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}
+
+// TestServiceListRoles 覆盖角色列表的成功与失败场景。
+func TestServiceListRoles(t *testing.T) {
+	cases := []struct {
+		name      string
+		prepare   func(*mockRepository)
+		wantErr   bool
+		wantCount int
+	}{
+		{
+			name: "成功获取列表",
+			prepare: func(m *mockRepository) {
+				m.On("ListRoles", mock.Anything).Return([]Role{{Name: "ADMIN"}}, nil)
+			},
+			wantCount: 1,
+		},
+		{
+			name:    "数据库错误",
+			prepare: func(m *mockRepository) { m.On("ListRoles", mock.Anything).Return(nil, errors.New("db")) },
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockRepo := &mockRepository{}
+			tc.prepare(mockRepo)
+			svc := newMockService(mockRepo)
+
+			roles, err := svc.ListRoles(context.Background())
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Len(t, roles, tc.wantCount)
+			}
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}
+
+// TestServiceCreatePermission 校验权限创建逻辑的输入校验与错误传播。
+func TestServiceCreatePermission(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   CreatePermissionInput
+		prepare func(*mockRepository)
+		wantErr bool
+	}{
+		{
+			name:  "成功创建并小写化字段",
+			input: CreatePermissionInput{Resource: " System ", Action: "VIEW", Description: "查看"},
+			prepare: func(m *mockRepository) {
+				m.On("CreatePermission", mock.Anything, mock.MatchedBy(func(p *Permission) bool {
+					return p.Resource == "system" && p.Action == "view" && p.Description == "查看"
+				})).Return(nil)
+			},
+		},
+		{
+			name:    "缺失字段",
+			input:   CreatePermissionInput{Resource: "  ", Action: ""},
+			prepare: func(m *mockRepository) {},
+			wantErr: true,
+		},
+		{
+			name:  "仓储错误",
+			input: CreatePermissionInput{Resource: "system", Action: "edit"},
+			prepare: func(m *mockRepository) {
+				m.On("CreatePermission", mock.Anything, mock.AnythingOfType("*rbac.Permission")).Return(errors.New("db"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockRepo := &mockRepository{}
+			tc.prepare(mockRepo)
+			svc := newMockService(mockRepo)
+
+			permission, err := svc.CreatePermission(context.Background(), tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Nil(t, permission)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, permission)
+			}
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}
+
+// TestServiceUpdatePermission 使用表驱动覆盖权限更新逻辑。
+func TestServiceUpdatePermission(t *testing.T) {
+	newResource := " ACCOUNT "
+	newAction := "LIST"
+	newDesc := "列出账户"
+	cases := []struct {
+		name    string
+		input   UpdatePermissionInput
+		prepare func(*mockRepository)
+		wantErr bool
+	}{
+		{
+			name: "成功更新所有字段",
+			input: UpdatePermissionInput{
+				ID:          uuid.New(),
+				Resource:    &newResource,
+				Action:      &newAction,
+				Description: &newDesc,
+			},
+			prepare: func(m *mockRepository) {
+				existing := &Permission{ID: uuid.New(), Resource: "system", Action: "view"}
+				m.On("FindPermissionByID", mock.Anything, mock.Anything).Return(existing, nil)
+				m.On("UpdatePermission", mock.Anything, mock.MatchedBy(func(p *Permission) bool {
+					return p.Resource == "account" && p.Action == "list" && p.Description == "列出账户"
+				})).Return(nil)
+			},
+		},
+		{
+			name:  "资源为空触发错误",
+			input: UpdatePermissionInput{ID: uuid.New(), Resource: func() *string { v := " "; return &v }()},
+			prepare: func(m *mockRepository) {
+				existing := &Permission{ID: uuid.New(), Resource: "system", Action: "view"}
+				m.On("FindPermissionByID", mock.Anything, mock.Anything).Return(existing, nil)
+			},
+			wantErr: true,
+		},
+		{
+			name:  "查找失败",
+			input: UpdatePermissionInput{ID: uuid.New()},
+			prepare: func(m *mockRepository) {
+				m.On("FindPermissionByID", mock.Anything, mock.Anything).Return(nil, errors.New("db"))
+			},
+			wantErr: true,
+		},
+		{
+			name:  "保存失败",
+			input: UpdatePermissionInput{ID: uuid.New()},
+			prepare: func(m *mockRepository) {
+				existing := &Permission{ID: uuid.New(), Resource: "system", Action: "view"}
+				m.On("FindPermissionByID", mock.Anything, mock.Anything).Return(existing, nil)
+				m.On("UpdatePermission", mock.Anything, mock.AnythingOfType("*rbac.Permission")).Return(errors.New("db"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockRepo := &mockRepository{}
+			tc.prepare(mockRepo)
+			svc := newMockService(mockRepo)
+
+			permission, err := svc.UpdatePermission(context.Background(), tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Nil(t, permission)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, permission)
+			}
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}
+
+// TestServiceDeletePermission 验证删除权限时的错误处理。
+func TestServiceDeletePermission(t *testing.T) {
+	permissionID := uuid.New()
+	cases := []struct {
+		name    string
+		prepare func(*mockRepository)
+		wantErr bool
+	}{
+		{
+			name: "删除成功",
+			prepare: func(m *mockRepository) {
+				m.On("DeletePermission", mock.Anything, permissionID).Return(nil)
+			},
+		},
+		{
+			name: "删除失败",
+			prepare: func(m *mockRepository) {
+				m.On("DeletePermission", mock.Anything, permissionID).Return(errors.New("db"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockRepo := &mockRepository{}
+			tc.prepare(mockRepo)
+			svc := newMockService(mockRepo)
+
+			err := svc.DeletePermission(context.Background(), DeletePermissionInput{ID: permissionID})
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}
+
+// TestServiceListPermissions 覆盖权限列表获取逻辑。
+func TestServiceListPermissions(t *testing.T) {
+	cases := []struct {
+		name      string
+		prepare   func(*mockRepository)
+		wantErr   bool
+		wantCount int
+	}{
+		{
+			name: "返回数据",
+			prepare: func(m *mockRepository) {
+				m.On("ListPermissions", mock.Anything).Return([]Permission{{Resource: "system", Action: "view"}}, nil)
+			},
+			wantCount: 1,
+		},
+		{
+			name:    "仓储错误",
+			prepare: func(m *mockRepository) { m.On("ListPermissions", mock.Anything).Return(nil, errors.New("db")) },
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockRepo := &mockRepository{}
+			tc.prepare(mockRepo)
+			svc := newMockService(mockRepo)
+
+			permissions, err := svc.ListPermissions(context.Background())
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Len(t, permissions, tc.wantCount)
+			}
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}
+
+// TestServiceAssignPermissions 覆盖权限分配给角色的完整分支。
+func TestServiceAssignPermissions(t *testing.T) {
+	roleID := uuid.New()
+	validKeys := []string{"system:view", " invalid "}
+	cases := []struct {
+		name    string
+		input   AssignRolePermissionsInput
+		prepare func(*mockRepository)
+		wantErr bool
+	}{
+		{
+			name:  "成功替换权限集合",
+			input: AssignRolePermissionsInput{RoleID: roleID, Permissions: validKeys},
+			prepare: func(m *mockRepository) {
+				role := &Role{ID: roleID}
+				perms := []*Permission{{ID: uuid.New(), Resource: "system", Action: "view"}}
+				m.On("FindRoleByID", mock.Anything, roleID).Return(role, nil)
+				m.On("FindPermissionsByKeys", mock.Anything, []string{"system:view"}).Return(perms, nil)
+				m.On("ReplaceRolePermissions", mock.Anything, role, perms).Return(nil)
+			},
+		},
+		{
+			name:    "无效权限键",
+			input:   AssignRolePermissionsInput{RoleID: roleID, Permissions: []string{"  "}},
+			prepare: func(m *mockRepository) {},
+			wantErr: true,
+		},
+		{
+			name:  "角色不存在",
+			input: AssignRolePermissionsInput{RoleID: roleID, Permissions: []string{"system:view"}},
+			prepare: func(m *mockRepository) {
+				m.On("FindRoleByID", mock.Anything, roleID).Return(nil, gorm.ErrRecordNotFound)
+			},
+			wantErr: true,
+		},
+		{
+			name:  "权限不存在",
+			input: AssignRolePermissionsInput{RoleID: roleID, Permissions: []string{"system:view"}},
+			prepare: func(m *mockRepository) {
+				role := &Role{ID: roleID}
+				m.On("FindRoleByID", mock.Anything, roleID).Return(role, nil)
+				m.On("FindPermissionsByKeys", mock.Anything, []string{"system:view"}).Return(nil, nil)
+			},
+			wantErr: true,
+		},
+		{
+			name:  "替换失败",
+			input: AssignRolePermissionsInput{RoleID: roleID, Permissions: []string{"system:view"}},
+			prepare: func(m *mockRepository) {
+				role := &Role{ID: roleID}
+				perms := []*Permission{{ID: uuid.New(), Resource: "system", Action: "view"}}
+				m.On("FindRoleByID", mock.Anything, roleID).Return(role, nil)
+				m.On("FindPermissionsByKeys", mock.Anything, []string{"system:view"}).Return(perms, nil)
+				m.On("ReplaceRolePermissions", mock.Anything, role, perms).Return(errors.New("db"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockRepo := &mockRepository{}
+			tc.prepare(mockRepo)
+			svc := newMockService(mockRepo)
+
+			role, err := svc.AssignPermissions(context.Background(), tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Nil(t, role)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, role)
+				require.Len(t, role.Permissions, 1)
+			}
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}
+
+// TestServiceGetRolePermissions 验证角色权限读取逻辑。
+func TestServiceGetRolePermissions(t *testing.T) {
+	roleID := uuid.New()
+	cases := []struct {
+		name    string
+		prepare func(*mockRepository)
+		wantErr bool
+		wantLen int
+	}{
+		{
+			name: "返回权限集合",
+			prepare: func(m *mockRepository) {
+				role := &Role{ID: roleID, Permissions: []*Permission{{Resource: "system", Action: "view"}}}
+				m.On("FindRoleByID", mock.Anything, roleID).Return(role, nil)
+			},
+			wantLen: 1,
+		},
+		{
+			name:    "查询失败",
+			prepare: func(m *mockRepository) { m.On("FindRoleByID", mock.Anything, roleID).Return(nil, errors.New("db")) },
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockRepo := &mockRepository{}
+			tc.prepare(mockRepo)
+			svc := newMockService(mockRepo)
+
+			keys, err := svc.GetRolePermissions(context.Background(), roleID)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Len(t, keys, tc.wantLen)
+			}
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}
+
+// TestServiceGetRolesByNames 测试批量角色查询的去重与错误分支。
+func TestServiceGetRolesByNames(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   []string
+		prepare func(*mockRepository)
+		wantErr bool
+		wantLen int
+	}{
+		{
+			name:  "成功获取并去重",
+			input: []string{" admin ", "ADMIN", "user"},
+			prepare: func(m *mockRepository) {
+				roles := []*Role{{Name: "ADMIN"}, {Name: "USER"}}
+				m.On("FindRolesByNames", mock.Anything, []string{"ADMIN", "USER"}).Return(roles, nil)
+			},
+			wantLen: 2,
+		},
+		{
+			name:  "仓储错误",
+			input: []string{"admin"},
+			prepare: func(m *mockRepository) {
+				m.On("FindRolesByNames", mock.Anything, []string{"ADMIN"}).Return(nil, errors.New("db"))
+			},
+			wantErr: true,
+		},
+		{
+			name:  "角色缺失",
+			input: []string{"admin", "user"},
+			prepare: func(m *mockRepository) {
+				roles := []*Role{{Name: "ADMIN"}}
+				m.On("FindRolesByNames", mock.Anything, []string{"ADMIN", "USER"}).Return(roles, nil)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockRepo := &mockRepository{}
+			tc.prepare(mockRepo)
+			svc := newMockService(mockRepo)
+
+			roles, err := svc.GetRolesByNames(context.Background(), tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Len(t, roles, tc.wantLen)
+			}
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}
+
+// TestServiceEnsurePermissionsExist 测试批量确保权限存在的多种分支。
+func TestServiceEnsurePermissionsExist(t *testing.T) {
+	cases := []struct {
+		name    string
+		keys    []string
+		prepare func(*mockRepository)
+		wantErr bool
+	}{
+		{
+			name: "创建缺失权限",
+			keys: []string{"system:view", "system:edit"},
+			prepare: func(m *mockRepository) {
+				existing := []*Permission{{Resource: "system", Action: "view"}}
+				m.On("FindPermissionsByKeys", mock.Anything, []string{"system:view", "system:edit"}).Return(existing, nil)
+				m.On("CreatePermission", mock.Anything, mock.MatchedBy(func(p *Permission) bool {
+					return p.Resource == "system" && p.Action == "edit"
+				})).Return(nil)
+			},
+		},
+		{
+			name: "查询失败",
+			keys: []string{"system:view"},
+			prepare: func(m *mockRepository) {
+				m.On("FindPermissionsByKeys", mock.Anything, []string{"system:view"}).Return(nil, errors.New("db"))
+			},
+			wantErr: true,
+		},
+		{
+			name:    "没有合法键跳过",
+			keys:    []string{"  "},
+			prepare: func(m *mockRepository) {},
+		},
+		{
+			name: "忽略重复错误",
+			keys: []string{"system:create"},
+			prepare: func(m *mockRepository) {
+				m.On("FindPermissionsByKeys", mock.Anything, []string{"system:create"}).Return(nil, nil)
+				m.On("CreatePermission", mock.Anything, mock.AnythingOfType("*rbac.Permission")).Return(gorm.ErrDuplicatedKey)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockRepo := &mockRepository{}
+			tc.prepare(mockRepo)
+			svc := newMockService(mockRepo)
+
+			err := svc.EnsurePermissionsExist(context.Background(), tc.keys)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}
+
+// TestServiceEnsureAdminHasAllPermissions 校验管理员同步逻辑。
+func TestServiceEnsureAdminHasAllPermissions(t *testing.T) {
+	cases := []struct {
+		name    string
+		prepare func(*mockRepository)
+		wantErr bool
+	}{
+		{
+			name: "成功同步",
+			prepare: func(m *mockRepository) {
+				adminRole := &Role{ID: uuid.New(), Name: NormalizeRoleName(constant.RoleAdmin)}
+				userRole := &Role{ID: uuid.New(), Name: NormalizeRoleName(constant.RoleUser)}
+				m.On("FindRoleByName", mock.Anything, NormalizeRoleName(constant.RoleAdmin)).Return(adminRole, nil).Twice()
+				m.On("FindRoleByName", mock.Anything, NormalizeRoleName(constant.RoleUser)).Return(userRole, nil)
+				perms := []Permission{{ID: uuid.New(), Resource: "system", Action: "view"}}
+				m.On("ListPermissions", mock.Anything).Return(perms, nil)
+				m.On("ReplaceRolePermissions", mock.Anything, adminRole, mock.MatchedBy(func(ps []*Permission) bool {
+					return len(ps) == 1 && ps[0].Resource == "system"
+				})).Return(nil)
+			},
+		},
+		{
+			name: "列权限失败",
+			prepare: func(m *mockRepository) {
+				adminRole := &Role{ID: uuid.New(), Name: NormalizeRoleName(constant.RoleAdmin)}
+				userRole := &Role{ID: uuid.New(), Name: NormalizeRoleName(constant.RoleUser)}
+				m.On("FindRoleByName", mock.Anything, NormalizeRoleName(constant.RoleAdmin)).Return(adminRole, nil).Twice()
+				m.On("FindRoleByName", mock.Anything, NormalizeRoleName(constant.RoleUser)).Return(userRole, nil)
+				m.On("ListPermissions", mock.Anything).Return(nil, errors.New("db"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockRepo := &mockRepository{}
+			tc.prepare(mockRepo)
+			svc := newMockService(mockRepo)
+
+			err := svc.EnsureAdminHasAllPermissions(context.Background())
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}
+
+// TestServiceHasPermission 确认权限检查会透传到底层仓储。
+func TestServiceHasPermission(t *testing.T) {
+	userID := uuid.New()
+	cases := []struct {
+		name    string
+		prepare func(*mockRepository)
+		wantErr bool
+		allowed bool
+	}{
+		{
+			name: "拥有权限",
+			prepare: func(m *mockRepository) {
+				m.On("UserHasPermission", mock.Anything, userID, "system:view").Return(true, nil)
+			},
+			allowed: true,
+		},
+		{
+			name: "查询错误",
+			prepare: func(m *mockRepository) {
+				m.On("UserHasPermission", mock.Anything, userID, "system:view").Return(false, errors.New("db"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockRepo := &mockRepository{}
+			tc.prepare(mockRepo)
+			svc := newMockService(mockRepo)
+
+			allowed, err := svc.HasPermission(context.Background(), userID, "system:view")
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.allowed, allowed)
+			}
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add SQLite-backed integration tests that exercise every repository method within rollbacked transactions
- introduce a repository contract for the service and add extensive table-driven unit tests with testify mocks
- add handler and middleware HTTP integration tests by mocking the service layer and verifying JSON responses
- include testify and SQLite drivers to support the new test suites

## Testing
- go vet ./internal/rbac... *(interrupted due to long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68da2521c67c832fb58f2e67bef3efe4