### PR TITLE
Refactor error handling architecture

### DIFF
--- a/internal/auth/errors.go
+++ b/internal/auth/errors.go
@@ -2,12 +2,11 @@ package auth
 
 import "github.com/Jayleonc/service/pkg/xerr"
 
+// 认证模块错误码范围：1000-1999
 var (
-	ErrRefreshInvalidPayload = xerr.New(1001, "invalid request payload")
-	ErrInvalidRefreshToken   = xerr.New(1002, "invalid refresh token")
-	ErrRefreshFailed         = xerr.New(1003, "failed to refresh token")
-
-	ErrMissingAuthorizationHeader = xerr.New(2001, "missing authorization header")
-	ErrInvalidAuthorizationHeader = xerr.New(2002, "invalid authorization header")
-	ErrInvalidToken               = xerr.New(2003, "invalid token")
+	ErrInvalidRefreshToken        = xerr.New(1001, "invalid refresh token")
+	ErrRefreshFailed              = xerr.New(1002, "failed to refresh token")
+	ErrMissingAuthorizationHeader = xerr.New(1101, "missing authorization header")
+	ErrInvalidAuthorizationHeader = xerr.New(1102, "invalid authorization header")
+	ErrInvalidToken               = xerr.New(1103, "invalid token")
 )

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Jayleonc/service/internal/feature"
 	"github.com/Jayleonc/service/pkg/ginx/response"
+	"github.com/Jayleonc/service/pkg/xerr"
 )
 
 // Handler 暴露认证模块的刷新令牌接口。
@@ -42,7 +43,7 @@ type refreshResponse struct {
 func (h *Handler) refresh(c *gin.Context) {
 	var req refreshRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.Error(c, http.StatusBadRequest, ErrRefreshInvalidPayload)
+		response.Error(c, http.StatusBadRequest, xerr.ErrBadRequest.WithMessage("invalid request payload"))
 		return
 	}
 

--- a/internal/middleware/errors.go
+++ b/internal/middleware/errors.go
@@ -2,7 +2,8 @@ package middleware
 
 import "github.com/Jayleonc/service/pkg/xerr"
 
+// 中间件模块错误码范围：4000-4999
 var (
-	ErrMissingSession        = xerr.New(2051, "missing session")
-	ErrInsufficientPrivilege = xerr.New(2052, "insufficient permissions")
+	ErrMissingSession        = xerr.New(4001, "missing session")
+	ErrInsufficientPrivilege = xerr.New(4002, "insufficient permissions")
 )

--- a/internal/rbac/errors.go
+++ b/internal/rbac/errors.go
@@ -1,12 +1,9 @@
 package rbac
 
-import "errors"
+import "github.com/Jayleonc/service/pkg/xerr"
 
+// RBAC 模块错误码范围：3000-3999
 var (
-	// ErrInvalidPayload indicates the request body failed validation.
-	ErrInvalidPayload = errors.New("invalid payload")
-	// ErrResourceNotFound indicates the target role or permission does not exist.
-	ErrResourceNotFound = errors.New("resource not found")
-	// ErrPermissionDenied indicates the user lacks the required permission.
-	ErrPermissionDenied = errors.New("permission denied")
+	ErrResourceNotFound = xerr.New(3001, "resource not found")
+	ErrPermissionDenied = xerr.New(3002, "permission denied")
 )

--- a/internal/rbac/handler.go
+++ b/internal/rbac/handler.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Jayleonc/service/internal/feature"
 	"github.com/Jayleonc/service/pkg/ginx/response"
+	"github.com/Jayleonc/service/pkg/xerr"
 )
 
 // Handler exposes management APIs for the RBAC module.
@@ -60,7 +61,7 @@ func (h *Handler) GetRoutes() feature.ModuleRoutes {
 func (h *Handler) createRole(c *gin.Context) {
 	var req CreateRoleInput
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.Error(c, http.StatusBadRequest, ErrInvalidPayload)
+		response.Error(c, http.StatusBadRequest, xerr.ErrBadRequest.WithMessage("invalid request payload"))
 		return
 	}
 
@@ -80,20 +81,20 @@ func (h *Handler) updateRole(c *gin.Context) {
 		Description string `json:"description"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.Error(c, http.StatusBadRequest, ErrInvalidPayload)
+		response.Error(c, http.StatusBadRequest, xerr.ErrBadRequest.WithMessage("invalid request payload"))
 		return
 	}
 
 	roleID, err := uuid.Parse(req.ID)
 	if err != nil {
-		response.Error(c, http.StatusBadRequest, ErrInvalidPayload)
+		response.Error(c, http.StatusBadRequest, xerr.ErrBadRequest.WithMessage("invalid role id"))
 		return
 	}
 
 	updated, err := h.svc.UpdateRole(c.Request.Context(), UpdateRoleInput{ID: roleID, Name: req.Name, Description: req.Description})
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			response.Error(c, http.StatusNotFound, ErrResourceNotFound)
+			response.Error(c, http.StatusNotFound, ErrResourceNotFound.WithMessage("role not found"))
 			return
 		}
 		response.Error(c, http.StatusBadRequest, err)
@@ -108,19 +109,19 @@ func (h *Handler) deleteRole(c *gin.Context) {
 		ID string `json:"id" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.Error(c, http.StatusBadRequest, ErrInvalidPayload)
+		response.Error(c, http.StatusBadRequest, xerr.ErrBadRequest.WithMessage("invalid request payload"))
 		return
 	}
 
 	roleID, err := uuid.Parse(req.ID)
 	if err != nil {
-		response.Error(c, http.StatusBadRequest, ErrInvalidPayload)
+		response.Error(c, http.StatusBadRequest, xerr.ErrBadRequest.WithMessage("invalid role id"))
 		return
 	}
 
 	if err := h.svc.DeleteRole(c.Request.Context(), DeleteRoleInput{ID: roleID}); err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			response.Error(c, http.StatusNotFound, ErrResourceNotFound)
+			response.Error(c, http.StatusNotFound, ErrResourceNotFound.WithMessage("role not found"))
 			return
 		}
 		response.Error(c, http.StatusBadRequest, err)
@@ -145,20 +146,20 @@ func (h *Handler) assignRolePermissions(c *gin.Context) {
 		Permissions []string `json:"permissions" binding:"required,min=1,dive,required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.Error(c, http.StatusBadRequest, ErrInvalidPayload)
+		response.Error(c, http.StatusBadRequest, xerr.ErrBadRequest.WithMessage("invalid request payload"))
 		return
 	}
 
 	roleID, err := uuid.Parse(req.RoleID)
 	if err != nil {
-		response.Error(c, http.StatusBadRequest, ErrInvalidPayload)
+		response.Error(c, http.StatusBadRequest, xerr.ErrBadRequest.WithMessage("invalid role id"))
 		return
 	}
 
 	role, err := h.svc.AssignPermissions(c.Request.Context(), AssignRolePermissionsInput{RoleID: roleID, Permissions: req.Permissions})
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			response.Error(c, http.StatusNotFound, ErrResourceNotFound)
+			response.Error(c, http.StatusNotFound, ErrResourceNotFound.WithMessage("role not found"))
 			return
 		}
 		response.Error(c, http.StatusBadRequest, err)
@@ -173,20 +174,20 @@ func (h *Handler) getRolePermissions(c *gin.Context) {
 		RoleID string `json:"roleId" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.Error(c, http.StatusBadRequest, ErrInvalidPayload)
+		response.Error(c, http.StatusBadRequest, xerr.ErrBadRequest.WithMessage("invalid request payload"))
 		return
 	}
 
 	roleID, err := uuid.Parse(req.RoleID)
 	if err != nil {
-		response.Error(c, http.StatusBadRequest, ErrInvalidPayload)
+		response.Error(c, http.StatusBadRequest, xerr.ErrBadRequest.WithMessage("invalid role id"))
 		return
 	}
 
 	permissions, err := h.svc.GetRolePermissions(c.Request.Context(), roleID)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			response.Error(c, http.StatusNotFound, ErrResourceNotFound)
+			response.Error(c, http.StatusNotFound, ErrResourceNotFound.WithMessage("role not found"))
 			return
 		}
 		response.Error(c, http.StatusBadRequest, err)
@@ -199,7 +200,7 @@ func (h *Handler) getRolePermissions(c *gin.Context) {
 func (h *Handler) createPermission(c *gin.Context) {
 	var req CreatePermissionInput
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.Error(c, http.StatusBadRequest, ErrInvalidPayload)
+		response.Error(c, http.StatusBadRequest, xerr.ErrBadRequest.WithMessage("invalid request payload"))
 		return
 	}
 
@@ -220,20 +221,20 @@ func (h *Handler) updatePermission(c *gin.Context) {
 		Description string `json:"description"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.Error(c, http.StatusBadRequest, ErrInvalidPayload)
+		response.Error(c, http.StatusBadRequest, xerr.ErrBadRequest.WithMessage("invalid permission id"))
 		return
 	}
 
 	permissionID, err := uuid.Parse(req.ID)
 	if err != nil {
-		response.Error(c, http.StatusBadRequest, ErrInvalidPayload)
+		response.Error(c, http.StatusBadRequest, xerr.ErrBadRequest.WithMessage("invalid permission id"))
 		return
 	}
 
 	updated, err := h.svc.UpdatePermission(c.Request.Context(), UpdatePermissionInput{ID: permissionID, Resource: req.Resource, Action: req.Action, Description: req.Description})
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			response.Error(c, http.StatusNotFound, ErrResourceNotFound)
+			response.Error(c, http.StatusNotFound, ErrResourceNotFound.WithMessage("permission not found"))
 			return
 		}
 		response.Error(c, http.StatusBadRequest, err)
@@ -248,19 +249,19 @@ func (h *Handler) deletePermission(c *gin.Context) {
 		ID string `json:"id" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.Error(c, http.StatusBadRequest, ErrInvalidPayload)
+		response.Error(c, http.StatusBadRequest, xerr.ErrBadRequest.WithMessage("invalid request payload"))
 		return
 	}
 
 	permissionID, err := uuid.Parse(req.ID)
 	if err != nil {
-		response.Error(c, http.StatusBadRequest, ErrInvalidPayload)
+		response.Error(c, http.StatusBadRequest, xerr.ErrBadRequest.WithMessage("invalid permission id"))
 		return
 	}
 
 	if err := h.svc.DeletePermission(c.Request.Context(), DeletePermissionInput{ID: permissionID}); err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			response.Error(c, http.StatusNotFound, ErrResourceNotFound)
+			response.Error(c, http.StatusNotFound, ErrResourceNotFound.WithMessage("permission not found"))
 			return
 		}
 		response.Error(c, http.StatusBadRequest, err)

--- a/internal/rbac/middleware.go
+++ b/internal/rbac/middleware.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Jayleonc/service/internal/feature"
 	"github.com/Jayleonc/service/pkg/constant"
 	"github.com/Jayleonc/service/pkg/ginx/response"
+	"github.com/Jayleonc/service/pkg/xerr"
 )
 
 // PermissionChecker describes the ability to validate whether a user possesses a permission.
@@ -32,7 +33,7 @@ func NewPermissionMiddleware(checker PermissionChecker) func(string) gin.Handler
 
 			session, ok := feature.GetAuthContext(c)
 			if !ok {
-				response.Error(c, http.StatusUnauthorized, ErrPermissionDenied)
+				response.Error(c, http.StatusUnauthorized, xerr.ErrUnauthorized.WithMessage("missing authorization context"))
 				c.Abort()
 				return
 			}

--- a/internal/user/errors.go
+++ b/internal/user/errors.go
@@ -2,35 +2,18 @@ package user
 
 import "github.com/Jayleonc/service/pkg/xerr"
 
+// 用户模块错误码范围：2000-2999
 var (
-	ErrRegisterInvalidPayload = xerr.New(3001, "invalid request payload")
-	ErrRegisterFailed         = xerr.New(3002, "failed to register user")
-	ErrEmailExists            = xerr.New(3003, "email already exists")
-
-	ErrLoginInvalidPayload = xerr.New(3011, "invalid request payload")
-	ErrLoginFailed         = xerr.New(3012, "failed to login user")
-	ErrInvalidCredentials  = xerr.New(3013, "invalid credentials")
-
-	ErrSessionMissing       = xerr.New(3021, "missing session")
-	ErrProfileLookupFailed  = xerr.New(3022, "failed to load profile")
-	ErrUpdateMeInvalidBody  = xerr.New(3032, "invalid request payload")
-	ErrUpdateProfileFailed  = xerr.New(3033, "failed to update profile")
-	ErrRolesRequired        = xerr.New(3034, "at least one role must be assigned")
-	ErrCreateInvalidPayload = xerr.New(3041, "invalid request payload")
-	ErrCreateFailed         = xerr.New(3042, "failed to create user")
-
-	ErrUpdateInvalidPayload = xerr.New(3051, "invalid request payload")
-	ErrInvalidUserID        = xerr.New(3052, "invalid user id")
-	ErrUpdateUserFailed     = xerr.New(3053, "failed to update user")
-
-	ErrDeleteInvalidPayload = xerr.New(3061, "invalid request payload")
-	ErrDeleteInvalidUserID  = xerr.New(3062, "invalid user id")
-	ErrDeleteUserFailed     = xerr.New(3063, "failed to delete user")
-
-	ErrListInvalidPayload = xerr.New(3071, "invalid request payload")
-	ErrListUsersFailed    = xerr.New(3072, "failed to list users")
-
-	ErrAssignInvalidPayload = xerr.New(3081, "invalid request payload")
-	ErrAssignInvalidUserID  = xerr.New(3082, "invalid user id")
-	ErrAssignRolesFailed    = xerr.New(3083, "failed to assign roles")
+	ErrRegisterFailed      = xerr.New(2001, "failed to register user")
+	ErrEmailExists         = xerr.New(2002, "email already exists")
+	ErrLoginFailed         = xerr.New(2011, "failed to login user")
+	ErrInvalidCredentials  = xerr.New(2012, "invalid credentials")
+	ErrProfileLookupFailed = xerr.New(2021, "failed to load profile")
+	ErrUpdateProfileFailed = xerr.New(2022, "failed to update profile")
+	ErrRolesRequired       = xerr.New(2023, "at least one role must be assigned")
+	ErrCreateFailed        = xerr.New(2031, "failed to create user")
+	ErrUpdateUserFailed    = xerr.New(2032, "failed to update user")
+	ErrDeleteUserFailed    = xerr.New(2033, "failed to delete user")
+	ErrListUsersFailed     = xerr.New(2034, "failed to list users")
+	ErrAssignRolesFailed   = xerr.New(2035, "failed to assign roles")
 )

--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Jayleonc/service/internal/feature"
 	"github.com/Jayleonc/service/pkg/ginx/request"
 	"github.com/Jayleonc/service/pkg/ginx/response"
+	"github.com/Jayleonc/service/pkg/xerr"
 )
 
 // Handler 对外提供用户模块的 HTTP 接口。
@@ -45,7 +46,7 @@ func (h *Handler) GetRoutes() feature.ModuleRoutes {
 func (h *Handler) register(c *gin.Context) {
 	var req RegisterInput
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.Error(c, http.StatusBadRequest, ErrRegisterInvalidPayload)
+		response.Error(c, http.StatusBadRequest, xerr.ErrBadRequest.WithMessage("invalid request payload"))
 		return
 	}
 
@@ -65,7 +66,7 @@ func (h *Handler) register(c *gin.Context) {
 func (h *Handler) login(c *gin.Context) {
 	var req LoginInput
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.Error(c, http.StatusBadRequest, ErrLoginInvalidPayload)
+		response.Error(c, http.StatusBadRequest, xerr.ErrBadRequest.WithMessage("invalid request payload"))
 		return
 	}
 
@@ -104,7 +105,7 @@ func (h *Handler) updateMe(c *gin.Context) {
 
 	var req UpdateProfileInput
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.Error(c, http.StatusBadRequest, ErrUpdateMeInvalidBody)
+		response.Error(c, http.StatusBadRequest, xerr.ErrBadRequest.WithMessage("invalid request payload"))
 		return
 	}
 
@@ -120,7 +121,7 @@ func (h *Handler) updateMe(c *gin.Context) {
 func (h *Handler) create(c *gin.Context) {
 	var req CreateUserRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.Error(c, http.StatusBadRequest, ErrCreateInvalidPayload)
+		response.Error(c, http.StatusBadRequest, xerr.ErrBadRequest.WithMessage("invalid request payload"))
 		return
 	}
 
@@ -144,13 +145,13 @@ func (h *Handler) update(c *gin.Context) {
 		Phone string `json:"phone"`
 	}
 	if err := c.ShouldBindJSON(&payload); err != nil {
-		response.Error(c, http.StatusBadRequest, ErrUpdateInvalidPayload)
+		response.Error(c, http.StatusBadRequest, xerr.ErrBadRequest.WithMessage("invalid request payload"))
 		return
 	}
 
 	userID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		response.Error(c, http.StatusBadRequest, ErrInvalidUserID)
+		response.Error(c, http.StatusBadRequest, xerr.ErrBadRequest.WithMessage("invalid user id"))
 		return
 	}
 
@@ -172,13 +173,13 @@ func (h *Handler) delete(c *gin.Context) {
 		ID string `json:"id" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&payload); err != nil {
-		response.Error(c, http.StatusBadRequest, ErrDeleteInvalidPayload)
+		response.Error(c, http.StatusBadRequest, xerr.ErrBadRequest.WithMessage("invalid request payload"))
 		return
 	}
 
 	userID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		response.Error(c, http.StatusBadRequest, ErrDeleteInvalidUserID)
+		response.Error(c, http.StatusBadRequest, xerr.ErrBadRequest.WithMessage("invalid user id"))
 		return
 	}
 
@@ -197,7 +198,7 @@ func (h *Handler) list(c *gin.Context) {
 		Email      string             `json:"email"`
 	}
 	if err := c.ShouldBindJSON(&payload); err != nil {
-		response.Error(c, http.StatusBadRequest, ErrListInvalidPayload)
+		response.Error(c, http.StatusBadRequest, xerr.ErrBadRequest.WithMessage("invalid request payload"))
 		return
 	}
 
@@ -220,13 +221,13 @@ func (h *Handler) assignRoles(c *gin.Context) {
 		Roles []string `json:"roles" binding:"required,min=1,dive,required"`
 	}
 	if err := c.ShouldBindJSON(&payload); err != nil {
-		response.Error(c, http.StatusBadRequest, ErrAssignInvalidPayload)
+		response.Error(c, http.StatusBadRequest, xerr.ErrBadRequest.WithMessage("invalid request payload"))
 		return
 	}
 
 	userID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		response.Error(c, http.StatusBadRequest, ErrAssignInvalidUserID)
+		response.Error(c, http.StatusBadRequest, xerr.ErrBadRequest.WithMessage("invalid user id"))
 		return
 	}
 

--- a/pkg/xerr/common_errors.go
+++ b/pkg/xerr/common_errors.go
@@ -1,0 +1,11 @@
+package xerr
+
+// 定义全局通用错误，错误码范围 1-999 预留给系统级错误使用。
+var (
+	ErrBadRequest     = New(400, "请求参数错误")
+	ErrUnauthorized   = New(401, "未授权")
+	ErrForbidden      = New(403, "禁止访问")
+	ErrNotFound       = New(404, "资源未找到")
+	ErrInternalServer = New(500, "服务器内部错误")
+	ErrDatabase       = New(501, "数据库错误")
+)


### PR DESCRIPTION
## Summary
- add centralized common error definitions under pkg/xerr and expose reusable WithMessage helpers
- realign auth, user, rbac, and middleware error codes to dedicated ranges while reusing shared bad request/not found errors in handlers
- update project-cli templates to rely on common errors and scaffold an errors.go file with namespace guidance for new features

## Testing
- golangci-lint run *(fails: command hung and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68da337a0a5c832f8840f6a46a0d1bc6