### PR TITLE
Automate RBAC resource registration in project-cli

### DIFF
--- a/cmd/project-cli/templates.go
+++ b/cmd/project-cli/templates.go
@@ -83,11 +83,11 @@ func (h *Handler) GetRoutes() feature.ModuleRoutes {
 return feature.ModuleRoutes{
 AuthenticatedRoutes: []feature.RouteDefinition{
 {{- if .EnableRBAC}}
-                {Path: "create", Handler: h.create, RequiredPermission: rbac.PermissionKey("{{.FeatureName}}", rbac.ActionCreate)},
-                {Path: "get_by_id", Handler: h.getByID, RequiredPermission: rbac.PermissionKey("{{.FeatureName}}", rbac.ActionRead)},
-                {Path: "update", Handler: h.update, RequiredPermission: rbac.PermissionKey("{{.FeatureName}}", rbac.ActionUpdate)},
-                {Path: "delete", Handler: h.delete, RequiredPermission: rbac.PermissionKey("{{.FeatureName}}", rbac.ActionDelete)},
-                {Path: "list", Handler: h.list, RequiredPermission: rbac.PermissionKey("{{.FeatureName}}", rbac.ActionList)},
+                {Path: "create", Handler: h.create, RequiredPermission: rbac.PermissionKey(rbac.Resource{{.PascalName}}, rbac.ActionCreate)},
+                {Path: "get_by_id", Handler: h.getByID, RequiredPermission: rbac.PermissionKey(rbac.Resource{{.PascalName}}, rbac.ActionRead)},
+                {Path: "update", Handler: h.update, RequiredPermission: rbac.PermissionKey(rbac.Resource{{.PascalName}}, rbac.ActionUpdate)},
+                {Path: "delete", Handler: h.delete, RequiredPermission: rbac.PermissionKey(rbac.Resource{{.PascalName}}, rbac.ActionDelete)},
+                {Path: "list", Handler: h.list, RequiredPermission: rbac.PermissionKey(rbac.Resource{{.PascalName}}, rbac.ActionList)},
 {{- else}}
                 {Path: "create", Handler: h.create},
                 {Path: "get_by_id", Handler: h.getByID},
@@ -545,11 +545,11 @@ func (h *Handler) GetRoutes() feature.ModuleRoutes {
 return feature.ModuleRoutes{
 AuthenticatedRoutes: []feature.RouteDefinition{
 {{- if .EnableRBAC}}
-                {Path: "create", Handler: h.create, RequiredPermission: rbac.PermissionKey("{{.FeatureName}}", rbac.ActionCreate)},
-                {Path: "get_by_id", Handler: h.getByID, RequiredPermission: rbac.PermissionKey("{{.FeatureName}}", rbac.ActionRead)},
-                {Path: "update", Handler: h.update, RequiredPermission: rbac.PermissionKey("{{.FeatureName}}", rbac.ActionUpdate)},
-                {Path: "delete", Handler: h.delete, RequiredPermission: rbac.PermissionKey("{{.FeatureName}}", rbac.ActionDelete)},
-                {Path: "list", Handler: h.list, RequiredPermission: rbac.PermissionKey("{{.FeatureName}}", rbac.ActionList)},
+                {Path: "create", Handler: h.create, RequiredPermission: rbac.PermissionKey(rbac.Resource{{.PascalName}}, rbac.ActionCreate)},
+                {Path: "get_by_id", Handler: h.getByID, RequiredPermission: rbac.PermissionKey(rbac.Resource{{.PascalName}}, rbac.ActionRead)},
+                {Path: "update", Handler: h.update, RequiredPermission: rbac.PermissionKey(rbac.Resource{{.PascalName}}, rbac.ActionUpdate)},
+                {Path: "delete", Handler: h.delete, RequiredPermission: rbac.PermissionKey(rbac.Resource{{.PascalName}}, rbac.ActionDelete)},
+                {Path: "list", Handler: h.list, RequiredPermission: rbac.PermissionKey(rbac.Resource{{.PascalName}}, rbac.ActionList)},
 {{- else}}
                 {Path: "create", Handler: h.create},
                 {Path: "get_by_id", Handler: h.getByID},


### PR DESCRIPTION
## Summary
- extend the new-feature generator to auto-register RBAC resources in permission_def.go when RBAC is enabled
- update handler templates to reference the generated resource constants instead of raw strings

## Testing
- go vet ./cmd/project-cli/...


------
https://chatgpt.com/codex/tasks/task_e_68da5deaafe4832fadf61cbc36a183fd